### PR TITLE
Implement ETag and Last-Modified

### DIFF
--- a/publ/caching.py
+++ b/publ/caching.py
@@ -42,7 +42,7 @@ def do_not_cache():
 def get_cache_tag(file, mtime):
     """ Get the ETag,Last-Modified for a file """
     etag = hashlib.md5(utils.file_fingerprint(
-        file).encode('utf-8')).hexdigest()[:8]
+        file).encode('utf-8')).hexdigest()[:16]
     return etag, mtime
 
 

--- a/publ/caching.py
+++ b/publ/caching.py
@@ -1,10 +1,19 @@
 # caching.py
 """ Useful caching functions """
 
+import os
+import hashlib
+import datetime
+
 from flask_caching import Cache
 from flask import request
+from pony import orm
 
 from . import config
+from . import index
+from . import utils
+from . import queries
+from . import model
 
 cache = Cache()  # pylint: disable=invalid-name
 
@@ -14,11 +23,74 @@ def init_app(app):
     cache.init_app(app, config=config.cache)
 
 
-def make_category_key():
-    """ Key generator for categories """
-    return 'category/' + request.full_path
+def do_not_cache():
+    """ Return whether we should cache a page render """
+
+    if index.in_progress():
+        # We are reindexing the site
+        return True
+
+    if request.if_none_match or request.if_modified_since:
+        # we might be returning a 304 NOT MODIFIED based on a client request,
+        # and we don't want to cache that as the result for *all* client
+        # requests to this URI
+        return True
+
+    return False
 
 
-def make_entry_key():
-    """ Key generator for entries """
-    return 'entry/' + request.path
+def get_cache_tag(file, mtime):
+    """ Get the ETag,Last-Modified for a file """
+    etag = hashlib.md5(utils.file_fingerprint(
+        file).encode('utf-8')).hexdigest()[:8]
+    return etag, mtime
+
+
+def get_view_cache_tag(template, entry=None):
+    """ Get a pessimistic cache tag for a view
+
+    Arguments:
+
+    template -- the template file being used to render
+    entry -- the entry to use; defaults to the most recently-published entry
+
+    Returns (etag,last-modified)
+    """
+
+    candidates = []
+
+    # If no entry is specified, check the most recently indexed file
+    if not entry and index.last_modified.file:
+        candidates.append(index.last_modified())
+
+    # check the template file
+    candidates.append((template.mtime, template.file_path))
+
+    # check the most recently-published entry
+    if not entry:
+        with orm.db_session:
+            last_published = queries.build_query({}).order_by(
+                orm.desc(model.Entry.utc_date))[:1]
+            if last_published:
+                entry = last_published[0]
+
+    if entry:
+        entry_file = entry.file_path
+        candidates.append((os.stat(entry_file).st_mtime, entry_file))
+
+    last_mtime, last_file = max(candidates)
+    return get_cache_tag(last_file, last_mtime)
+
+
+def not_modified(etag, mtime):
+    """ Return True if the request indicates that our cache is valid """
+
+    if request.if_none_match.contains(etag):
+        return True
+
+    if request.if_modified_since:
+        mod_time = datetime.datetime.utcfromtimestamp(int(mtime))
+        if request.if_modified_since >= mod_time:
+            return True
+
+    return False

--- a/publ/caching.py
+++ b/publ/caching.py
@@ -90,12 +90,9 @@ def not_modified(etag, mtime):
     """ Return True if the request indicates that the client's cache is valid """
 
     if request.if_none_match.contains(etag):
-        # The ETag matched, so it's definitely the same file
         return True
 
     if request.if_modified_since:
-        # Check the modification time; this also covers the case where ETags vary
-        # because of load balancers having different file fingerprints
         mod_time = arrow.get(int(mtime))
         if request.if_modified_since >= mod_time:
             return True

--- a/publ/caching.py
+++ b/publ/caching.py
@@ -3,7 +3,6 @@
 
 import os
 import hashlib
-import datetime
 import arrow
 
 from flask_caching import Cache
@@ -88,12 +87,15 @@ def get_view_cache_tag(template, entry=None):
 
 
 def not_modified(etag, mtime):
-    """ Return True if the request indicates that our cache is valid """
+    """ Return True if the request indicates that the client's cache is valid """
 
     if request.if_none_match.contains(etag):
+        # The ETag matched, so it's definitely the same file
         return True
 
     if request.if_modified_since:
+        # Check the modification time; this also covers the case where ETags vary
+        # because of load balancers having different file fingerprints
         mod_time = arrow.get(int(mtime))
         if request.if_modified_since >= mod_time:
             return True

--- a/publ/template.py
+++ b/publ/template.py
@@ -20,7 +20,9 @@ class Template:
         """
         self.name = name
         self.filename = filename
-        self.last_modified = arrow.get(os.stat(file_path).st_mtime)
+        self.file_path = file_path
+        self.mtime = os.stat(file_path).st_mtime
+        self.last_modified = arrow.get(self.mtime)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Implements ETag and Last-Modified for cache control; resolves issue #129 

## Detailed description

For category and entry views, it generates a fingerprint and last-modified time of the most recent relevant file. The relevant files considered are:

* The view template
* The most recently-published entry (based on publish time, not file modification time)
* The most recently-indexed file
* The entry itself, if applicable

This is a pessimistic time stamp, the idea being that any modification to an entry might end up changing things like previous/next links or any sidebar showing recent changes or the like. This avoids having to do an expensive process of evaluating the template to see what related things have changed (which would defeat the entire purpose to this caching in the first place).

## Test plan

Using `feedparser` I manually tested a number of scenarios, including modifying entries and scheduling an entry for the future and watching the tag and last-modified change when its future date is reached.
