### PR TITLE
Improve internal reference links

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -98,7 +98,7 @@ class Category(caching.Memoizable):
         return utils.CallableProxy(None)
 
     @cached_property
-    def image_search_path(self):
+    def search_path(self):
         """ Get the image search path for the category """
         return [os.path.join(config.content_folder, self.path)]
 
@@ -125,7 +125,7 @@ class Category(caching.Memoizable):
     def _description(self, **kwargs):
         if self._meta:
             return flask.Markup(markdown.to_html(self._meta.get_payload(), config=kwargs,
-                                                 image_search_path=self.image_search_path))
+                                                 search_path=self.search_path))
         return None
 
     def __getattr__(self, name):

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -162,9 +162,9 @@ class Entry(caching.Memoizable):
         return markdown.render_title(self._record.title, markup, no_smartquotes)
 
     @cached_property
-    def image_search_path(self):
+    def search_path(self):
         """ The relative image search path for this entry """
-        return [os.path.dirname(self._record.file_path)] + self.category.image_search_path
+        return [os.path.dirname(self._record.file_path)] + self.category.search_path
 
     @cached_property
     def _message(self):
@@ -234,7 +234,7 @@ class Entry(caching.Memoizable):
             return markdown.to_html(
                 text,
                 config=kwargs,
-                image_search_path=self.image_search_path)
+                search_path=self.search_path)
 
         return flask.Markup(text)
 
@@ -248,7 +248,7 @@ class Entry(caching.Memoizable):
         tags = og_tag('og:title', self.title)
         tags += og_tag('og:url', self.link(absolute=True))
 
-        card = cards.extract_card(text, kwargs, self.image_search_path)
+        card = cards.extract_card(text, kwargs, self.search_path)
         for image in card.images:
             tags += og_tag('og:image', image)
         if card.description:

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -28,14 +28,20 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class HtmlRenderer(misaka.HtmlRenderer):
-    """ Customized renderer for enhancing Markdown formatting """
+    """ Customized renderer for enhancing Markdown formatting
 
-    def __init__(self, config, image_search_path):
+    Constructor arguments:
+
+    config -- The configuration for the Markdown tags
+    search_path -- Directories to look in for resolving relatively-linked files
+    """
+
+    def __init__(self, config, search_path):
         # pylint: disable=no-member
         super().__init__(0, config.get('xhtml') and misaka.HTML_USE_XHTML or 0)
 
         self._config = config
-        self._image_search_path = image_search_path
+        self._search_path = search_path
 
     def image(self, raw_url, title='', alt=''):
         """ Adapt a standard Markdown image to a generated rendition set.
@@ -155,7 +161,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
         composite_args = {**container_args, **image_args}
 
         try:
-            img = image.get_image(path, self._image_search_path)
+            img = image.get_image(path, self._search_path)
         except Exception as err:  # pylint: disable=broad-except
             logger.exception("Got error on image %s: %s", path, err)
             return ('<span class="error">Error loading image {}: {}</span>'.format(
@@ -164,9 +170,9 @@ class HtmlRenderer(misaka.HtmlRenderer):
         return img.get_img_tag(title, alt_text, **composite_args)
 
 
-def to_html(text, config, image_search_path):
+def to_html(text, config, search_path):
     """ Convert Markdown text to HTML """
-    processor = misaka.Markdown(HtmlRenderer(config, image_search_path),
+    processor = misaka.Markdown(HtmlRenderer(config, search_path),
                                 extensions=ENABLED_EXTENSIONS)
 
     text = processor(text)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -145,6 +145,11 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
     def _remap_path(self, path):
         """ Remap a path to an appropriate URL """
+
+        if not path.startswith('//') and not '://' in path:
+            found = utils.find_entry(path, self._search_path)
+            if found:
+                return found.link(self._config)
         return utils.remap_link_target(path, self._config.get('absolute'))
 
     def _render_image(self, spec, container_args, alt_text=None):

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -147,9 +147,9 @@ class HtmlRenderer(misaka.HtmlRenderer):
         """ Remap a path to an appropriate URL """
 
         if not path.startswith('//') and not '://' in path:
-            found = utils.find_entry(path, self._search_path)
-            if found:
-                return found.link(self._config)
+            entry = utils.find_entry(path, self._search_path)
+            if entry:
+                return entry.link(self._config)
         return utils.remap_link_target(path, self._config.get('absolute'))
 
     def _render_image(self, spec, container_args, alt_text=None):

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -101,11 +101,11 @@ def image_function(template=None, entry=None, category=None):
     path = []
 
     if entry is not None:
-        path += entry.image_search_path
+        path += entry.search_path
     if category is not None:
         # Since the category might be different than the entry's category we add
         # this too
-        path += category.image_search_path
+        path += category.search_path
     if template is not None:
         path.append(os.path.join(
             config.content_folder,


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Implement entry resolution for internal entry links; fixes #142 

## Detailed description

When a Markdown entry sees an internal link, it tries to resolve it as an entry first, using the search path for the template context (or the content directory if it starts with `/`). If this finds an entry, the link target is set to the entry's `link` attribute using the template's configuration.

For example, previously an entry link like

```markdown
[foo](123)
```

would just generate

```html
<a href="123">foo</a>
```

which would require at least a redirect to the entry from the path resolver, and also required external feed readers to be savvy enough to rewrite URLs (which is technically a violation of the Atom spec although most feed readers do the rewriting even though they're not supposed to). Now it will generate a link like:

```html
<a href="/example/123-some-foo">foo</a>
```

or, in an absolute context (e.g. a feed),

```html
<a href="http://example.com/example/123-some-foo">foo</a>
```

But the primary improvement here is that it will also resolve links to entries by filename; for example, all of the below should work:

```markdown
[some other entry](other-entry.md)
[in a parent directory](../other-entry.md)
[relative to content root](/blog/other-entry.md)
```

Currently this only remaps entries; if a link goes to e.g. a category it will still just resolve as a regular relative link, e.g. `[my blog](/blog)` still goes to `<a href="/blog">my blog</a>`. Supporting categories or other unresolved relative links should be done using a different mechanism, ideally doing a `url_join` on the Flask request URL (and only in an absolute context).

## Test plan

See https://github.com/PlaidWeb/publ-site/blob/pending/v0.3.11/content/tests/relative%20entry%20links.md
