### PR TITLE
Get Publ working natively on Windows

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -226,8 +226,7 @@ def scan_file(fullpath, relpath):
         return True
 
     # update the category meta file mapping
-    category = meta.get(
-        'Category', utils.get_category(os.path.dirname(relpath)))
+    category = meta.get('Category', utils.get_category(relpath))
     values = {
         'category': category,
         'file_path': fullpath,

--- a/publ/category.py
+++ b/publ/category.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 def load_metafile(filepath):
     """ Load a metadata file from the filesystem """
     try:
-        with open(filepath, 'r') as file:
+        with open(filepath, 'r', encoding='utf-8') as file:
             return email.message_from_file(file)
     except FileNotFoundError:
         logger.warning("Category file %s not found", filepath)
@@ -226,7 +226,8 @@ def scan_file(fullpath, relpath):
         return True
 
     # update the category meta file mapping
-    category = meta.get('Category', os.path.dirname(relpath))
+    category = meta.get(
+        'Category', utils.get_category(os.path.dirname(relpath)))
     values = {
         'category': category,
         'file_path': fullpath,

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -332,7 +332,7 @@ def get_entry_id(entry, fullpath, assign_id):
     if entry_id:
         other_entry = model.Entry.get(id=entry_id)
         if (other_entry
-                and other_entry.file_path != fullpath
+                and not os.path.samefile(other_entry.file_path, fullpath)
                 and os.path.isfile(other_entry.file_path)):
             warn_duplicate = entry_id
             entry_id = None

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 @functools.lru_cache(10)
 def load_message(filepath):
     """ Load a message from the filesystem """
-    with open(filepath, 'r') as file:
+    with open(filepath, 'r', encoding='utf-8') as file:
         return email.message_from_file(file)
 
 

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -414,7 +414,7 @@ def scan_file(fullpath, relpath, assign_id):
 
     values = {
         'file_path': fullpath,
-        'category': entry.get('Category', os.path.dirname(relpath)),
+        'category': entry.get('Category', utils.get_category(relpath)),
         'status': model.PublishStatus[entry.get('Status', 'SCHEDULED').upper()].value,
         'entry_type': entry.get('Entry-Type', ''),
         'slug_text': make_slug(entry.get('Slug-Text', title)),

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -121,7 +121,7 @@ def render_publ_template(template, **kwargs):
     Returns tuple of (rendered text, etag)
     """
     text = render_template(
-        template.filename,
+        os.path.normpath(template.filename),
         template=template,
         image=image_function(
             template=template,

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -121,7 +121,7 @@ def render_publ_template(template, **kwargs):
     Returns tuple of (rendered text, etag)
     """
     text = render_template(
-        os.path.normpath(template.filename),
+        template.filename,
         template=template,
         image=image_function(
             template=template,

--- a/publ/template.py
+++ b/publ/template.py
@@ -19,7 +19,13 @@ class Template:
         file_path -- The full path to the template
         """
         self.name = name
-        self.filename = filename
+
+        # on Windows, Flask expects template filenames to be /-separated
+        if os.sep != '/':
+            self.filename = '/'.join(os.path.normpath(filename).split(os.sep))
+        else:
+            self.filename = filename
+
         self.file_path = file_path
         self.mtime = os.stat(file_path).st_mtime
         self.last_modified = arrow.get(self.mtime)

--- a/publ/template.py
+++ b/publ/template.py
@@ -20,7 +20,8 @@ class Template:
         """
         self.name = name
 
-        # on Windows, Flask expects template filenames to be /-separated
+        # Flask expects template filenames to be /-separated regardless of
+        # platform
         if os.sep != '/':
             self.filename = '/'.join(os.path.normpath(filename).split(os.sep))
         else:

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -189,6 +189,10 @@ def static_url(path, absolute=False):
     path -- the path to the file (relative to the static files directory)
     absolute -- whether the link should be absolute or relative
     """
+
+    if os.sep != '/':
+        path = '/'.join(path.split(os.sep))
+
     return flask.url_for('static', filename=path, _external=absolute)
 
 

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -253,3 +253,8 @@ def remap_link_target(path, absolute=False):
         return urllib.parse.urljoin(flask.request.url, path)
 
     return path
+
+
+def get_category(filename):
+    """ Get a default category name from a filename in a cross-platform manner """
+    return '/'.join(os.path.dirname(filename).split(os.sep))


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

It now works on Windows! Fixes #97 (finally)

## Detailed description

The problems all turned out to be due to path separator stuff. Fixing everything required:

* use `os.path.samefile` for file path comparisons
* Normalize paths using `os.normpath` wherever Publ was touching file paths
* Denormalize everything back to using `/` wherever Flask was touching it, because Flask fixes that on its own

Also it turns out that Python 3 still defaults to ISO-8859-1 even in the year 2018, so all `file()` calls now have an explicit encoding set.

## Test plan

Tested Publ-site thoroughly on both Windows and macOS
