### PR TITLE
Support entry and image links in plain-HTML entries

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -25,6 +25,7 @@ from . import markdown
 from . import utils
 from . import cards
 from . import caching
+from . import html_entry
 from .utils import CallableProxy, TrueCallableProxy, make_slug
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -99,7 +100,7 @@ class Entry(caching.Memoizable):
     @cached_property
     def status(self):
         """ Returns a string version of the entry status """
-        return Model.PublishStatus(self.status)
+        return model.PublishStatus(self.status)
 
     @cached_property
     def next(self):
@@ -246,7 +247,10 @@ class Entry(caching.Memoizable):
                 config=kwargs,
                 search_path=self.search_path)
 
-        return flask.Markup(text)
+        return html_entry.process(
+            text,
+            config=kwargs,
+            search_path=self.search_path)
 
     def _get_card(self, text, **kwargs):
         """ Render out the tags for a Twitter/OpenGraph card for this entry. """

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -1,0 +1,127 @@
+# html_entry.py
+""" HTML entry processing functionality """
+
+import html.parser
+
+import misaka
+import flask
+
+from . import utils
+from . import image
+
+
+class HTMLEntry(html.parser.HTMLParser):
+    """ An HTML manipulator to fixup src and href attributes """
+
+    def __init__(self, config, search_path):
+        super().__init__()
+
+        self._search_path = search_path
+        self._config = config
+
+        self.reset()
+        self.strict = False
+        self.convert_charrefs = False
+        self.fed = []
+
+    def handle_data(self, data):
+        """ Simply append the text data """
+        self.fed.append(data)
+
+    def get_data(self):
+        """ Concatenate the output """
+        return ''.join(self.fed)
+
+    def handle_starttag(self, tag, attrs):
+        """ Handle a start tag """
+        self._handle_tag(tag, attrs, False)
+
+    def handle_endtag(self, tag):
+        """ Handle an end tag """
+        self.fed.append('</' + tag + '>')
+
+    def handle_startendtag(self, tag, attrs):
+        """ Handle a self-closing tag """
+        self._handle_tag(tag, attrs, True)
+
+    def error(self, message):
+        """ Deprecated, per https://bugs.python.org/issue31844 """
+        return message
+
+    def _handle_tag(self, tag, attrs, self_closing):
+        """ Handle a tag.
+
+        attrs -- the attributes of the tag
+        self_closing -- whether this is self-closing
+        """
+
+        if tag.lower() == 'img':
+            attrs = self._image_attrs(attrs)
+
+        # Remap the attributes
+        out_attrs = []
+        for key, val in attrs:
+            if key.lower() == 'href':
+                out_attrs.append((key, self._remap_path(val)))
+            else:
+                out_attrs.append((key, val))
+
+        self.fed.append(
+            utils.make_tag(
+                tag,
+                out_attrs,
+                self_closing))
+
+    def _image_attrs(self, attrs):
+        """ Rewrite the SRC attribute on an <img> tag, possibly adding a SRCSET.
+        """
+
+        path = None
+        config = self._config
+
+        for key, val in attrs:
+            if key.lower() == 'width' or key.lower() == 'height':
+                try:
+                    config = {**config, key.lower(): int(val)}
+                except ValueError:
+                    pass
+            elif key.lower() == 'src':
+                path = val
+
+        img = image.get_image(path, self._search_path)
+
+        try:
+            img_attrs = {k: v for k, v in img.get_img_attrs(**config)}
+        except FileNotFoundError as error:
+            return [('data-publ-error', 'file not found: {}'.format(error.filename))]
+
+        return [(key, val) for key, val in attrs if key not in img_attrs] + list(img_attrs.items())
+
+    def _remap_path(self, path):
+        """ Remap a link target to an appropriate URL """
+
+        # Remote or static URL: do the thing
+        if not path.startswith('//') and not '://' in path:
+            path, sep, anchor = path.partition('#')
+            entry = utils.find_entry(path, self._search_path)
+            if entry:
+                return entry.link(self._config) + sep + anchor
+
+        # Image URL: do the thing
+        img_path, img_args, _ = image.parse_image_spec(path)
+        img = image.get_image(img_path, self._search_path)
+        if isinstance(img, image.LocalImage):
+            path, _ = img.get_rendition(**img_args)
+
+        return utils.remap_link_target(path, self._config.get('absolute'))
+
+
+def process(text, config, search_path):
+    processor = HTMLEntry(config, search_path)
+    processor.feed(text)
+    text = processor.get_data()
+
+    if not config.get('no_smartquotes'):
+        text = misaka.smartypants(text)
+
+    return flask.Markup(text)

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -76,21 +76,18 @@ class HTMLEntry(utils.HTMLTransform):
         img_path, img_args, _ = image.parse_image_spec(path)
         img = image.get_image(img_path, self._search_path)
 
-        print('img_args', img_args)
-        print(config)
-
         for key, val in img_args.items():
             print(key, val)
             if val and key not in config:
                 config[key] = val
 
         try:
-            img_attrs = {k: v for k, v in img.get_img_attrs(**config)}
+            img_attrs = img.get_img_attrs(**config)
         except FileNotFoundError as error:
             return [('data-publ-error', 'file not found: {}'.format(error.filename))]
 
         # return the original attr list with the computed overrides in place
-        return [(key, val) for key, val in attrs if key not in img_attrs] + list(img_attrs.items())
+        return [(key, val) for key, val in attrs if key not in img_attrs] + [i for i in img_attrs.items()]
 
 
 def process(text, config, search_path):

--- a/publ/image.py
+++ b/publ/image.py
@@ -58,7 +58,7 @@ class Image(ABC):
 
         style -- an optional list of CSS style fragments
 
-        Returns: a list of tuples e.g. [('src','foo.jpg'),('srcset','foo.jpg 1x, bar.jpg 2x')]
+        Returns: a dict of attributes e.g. {'src':'foo.jpg','srcset':'foo.jpg 1x, bar.jpg 2x']
         """
 
     def get_img_tag(self, title='', alt_text='', **kwargs):
@@ -84,11 +84,11 @@ class Image(ABC):
                 if shape:
                     style.append("shape-outside: url('{}')".format(shape))
 
-            attrs = [
-                ('alt_text', alt_text),
-                ('title', title if title else None),
-                *self.get_img_attrs(style, **kwargs)
-            ]
+            attrs = {
+                'alt_text': alt_text,
+                'title': title,
+                **self.get_img_attrs(style, **kwargs)
+            }
 
             return flask.Markup(
                 self._wrap_link_target(
@@ -540,16 +540,15 @@ class LocalImage(Image):
         # Get the 1x and 2x renditions
         img_1x, img_2x, size = self._get_renditions(kwargs)
 
-        return [
-            ('src', img_1x),
-            ('width', size[0]),
-            ('height', size[1]),
-            ('srcset', "{} 1x, {} 2x".format(img_1x, img_2x)
-             if img_1x != img_2x else None),
-            ('style', ';'.join(style) if style else None),
-            ('class', kwargs.get('class', kwargs.get('img_class'))),
-            ('id', kwargs.get('img_id'))
-        ]
+        return {
+            'src': img_1x,
+            'width': size[0],
+            'height': size[1],
+            'srcset': "{} 1x, {} 2x".format(img_1x, img_2x) if img_1x != img_2x else None,
+            'style': ';'.join(style) if style else None,
+            'class': kwargs.get('class', kwargs.get('img_class')),
+            'id': kwargs.get('img_id')
+        }
 
     def _css_background(self, **kwargs):
         """ Get the CSS specifiers for this as a hidpi-capable background image """
@@ -613,10 +612,10 @@ class RemoteImage(Image):
         return self.url, None
 
     def get_img_attrs(self, style=None, **kwargs):
-        attrs = [
-            ('class', kwargs.get('class', kwargs.get('img_class'))),
-            ('id', kwargs.get('img_id')),
-        ]
+        attrs = {
+            'class': kwargs.get('class', kwargs.get('img_class')),
+            'id': kwargs.get('img_id'),
+        }
 
         # try to fudge the sizing
         max_width = kwargs.get('max_width')
@@ -645,15 +644,16 @@ class RemoteImage(Image):
                     kwargs.get('fill_crop_y', 0.5) * 100),
                 'background-repeat:no-repeat'
             ]
-            attrs.append(('src', flask.url_for(
-                'chit', _external=kwargs.get('absolute'))))
+            attrs['src'] = flask.url_for(
+                'chit', _external=kwargs.get('absolute'))
         else:
-            attrs.append(('src', self.url))
+            attrs['src'] = self.url
 
-        attrs += [('width', width), ('height', height)]
+        attrs['width'] = width
+        attrs['height'] = height
 
         if style_parts:
-            attrs.append(('style', ';'.join(style_parts)))
+            attrs['style'] = ';'.join(style_parts)
 
         return attrs
 

--- a/publ/image.py
+++ b/publ/image.py
@@ -677,9 +677,9 @@ class StaticImage(Image):
         url = utils.static_url(self.path, absolute=kwargs.get('absolute'))
         return RemoteImage(url, self.search_path).get_rendition(output_scale, **kwargs)
 
-    def get_img_attrs(self, title='', alt_text='', style=None, **kwargs):
+    def get_img_attrs(self, style=None, **kwargs):
         url = utils.static_url(self.path, absolute=kwargs.get('absolute'))
-        return RemoteImage(url, self.search_path).get_img_attrs(title, alt_text, style, **kwargs)
+        return RemoteImage(url, self.search_path).get_img_attrs(style, **kwargs)
 
     def _css_background(self, **kwargs):
         # pylint: disable=arguments-differ

--- a/publ/links.py
+++ b/publ/links.py
@@ -1,0 +1,24 @@
+# links.py
+""" Functions for manipulating outgoing HTML links """
+
+from . import image
+from . import utils
+
+
+def remap_path(path, search_path, absolute=False):
+    """ Remap a link or source target to an appropriate entry or image rendition """
+
+    # Remote or static URL: do the thing
+    if not path.startswith('//') and not '://' in path:
+        path, sep, anchor = path.partition('#')
+        entry = utils.find_entry(path, search_path)
+        if entry:
+            return entry.link(absolute=absolute) + sep + anchor
+
+    # Image URL: do the thing
+    img_path, img_args, _ = image.parse_image_spec(path)
+    img = image.get_image(img_path, search_path)
+    if isinstance(img, image.LocalImage):
+        path, _ = img.get_rendition(**img_args)
+
+    return utils.remap_link_target(path, absolute)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -1,7 +1,5 @@
 # markdown.py
-""" handler for markdown formatting """
-
-from __future__ import absolute_import
+""" markdown formatting functionality """
 
 import logging
 import html.parser
@@ -247,10 +245,6 @@ class HTMLStripper(html.parser.HTMLParser):
     def get_data(self):
         """ Concatenate the output """
         return ''.join(self.fed)
-
-    def error(self, message):
-        """ Deprecated, per https://bugs.python.org/issue31844 """
-        return message
 
 
 def render_title(text, markup=True, no_smartquotes=False):

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -207,7 +207,15 @@ def make_tag(name, attrs, start_end=False):
     """
 
     text = '<' + name
-    for key, val in attrs.items():
+
+    if isinstance(attrs, dict):
+        attr_list = attrs.items()
+    elif isinstance(attrs, list):
+        attr_list = attrs
+    elif attrs is not None:
+        raise TypeError("Unhandled attrs type " + str(type(attrs)))
+
+    for key, val in attr_list:
         if val is not None:
             escaped = html.escape(str(val), False).replace('"', '&#34;')
             text += ' {}="{}"'.format(key, escaped)

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, with_statement
 import re
 import os
 import html
+import html.parser
 import urllib.parse
 
 import arrow
@@ -270,3 +271,34 @@ def remap_link_target(path, absolute=False):
 def get_category(filename):
     """ Get a default category name from a filename in a cross-platform manner """
     return '/'.join(os.path.dirname(filename).split(os.sep))
+
+
+class HTMLTransform(html.parser.HTMLParser):
+    """ Wrapper to HTMLParser to make it easier to build a SAX-style processor.
+
+    You will probably want to implement:
+        handle_starttag(self, tag, attrs)
+        handle_endtag(self, tag)
+        handle_data(self, data)
+        handle_startendtag(self, tag, attrs)
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.reset()
+        self.strict = False
+        self.convert_charrefs = False
+        self._fed = []
+
+    def append(self, item):
+        """ Append some text to the output """
+        self._fed.append(item)
+
+    def get_data(self):
+        """ Concatenate the output """
+        return ''.join(self._fed)
+
+    def error(self, message):
+        """ Deprecated, per https://bugs.python.org/issue31844 """
+        return message


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Supports rewriting link and image targets in HTML entries; fixes #136 and #154.

## Detailed description

This adds a simple HTML transform step which scans all elements for `href` and `src` links, and rewrites their targets appropriately. In the case of `<img>` tags it also uses the `width` and `height` attributes in addition to the template configuration to select the appropriate renditions.

## Developer/user impact

Adds a lot of functionality to HTML entries, but also changes the Image API somewhat. See https://github.com/PlaidWeb/publ-site/commit/baaea3b6737a7ca816bfa0113d23908af2237d85 for related documentation changes.

## Test plan

Added tests in https://github.com/PlaidWeb/publ-site/commit/baaea3b6737a7ca816bfa0113d23908af2237d85
