### PR TITLE
Support linking to non-image asset files

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -91,6 +91,9 @@ def publ(name, cfg):
 
     app.add_url_rule('/_', 'chit', rendering.render_transparent_chit)
 
+    app.add_url_rule('/_file/<path:filename>',
+                     'asset', rendering.retrieve_asset)
+
     app.config['TRAP_HTTP_EXCEPTIONS'] = True
     app.register_error_handler(
         werkzeug.exceptions.HTTPException, rendering.render_exception)

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -142,8 +142,8 @@ class Entry(caching.Memoizable):
     def _link(self, *args, **kwargs):
         """ Returns a link, potentially pre-redirected """
         if self._record.redirect_url:
-            return links.remap_path(self._record.redirect_url,
-                                    self.search_path, kwargs.get('absolute'))
+            return links.resolve(self._record.redirect_url,
+                                 self.search_path, kwargs.get('absolute'))
 
         return self._permalink(*args, **kwargs)
 

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -46,7 +46,7 @@ class HTMLEntry(utils.HTMLTransform):
         for key, val in attrs:
             if (key.lower() == 'href'
                     or (key.lower() == 'src' and not tag.lower() == 'img')):
-                out_attrs.append((key, links.remap_path(
+                out_attrs.append((key, links.resolve(
                     val, self._search_path, self._config.get('absolute'))))
             else:
                 out_attrs.append((key, val))

--- a/publ/links.py
+++ b/publ/links.py
@@ -1,24 +1,33 @@
 # links.py
 """ Functions for manipulating outgoing HTML links """
 
+import re
+
 from . import image
 from . import utils
 
 
-def remap_path(path, search_path, absolute=False):
+def resolve(path, search_path, absolute=False):
     """ Remap a link or source target to an appropriate entry or image rendition """
 
-    # Remote or static URL: do the thing
-    if not path.startswith('//') and not '://' in path:
-        path, sep, anchor = path.partition('#')
-        entry = utils.find_entry(path, search_path)
-        if entry:
-            return entry.permalink(absolute=absolute) + sep + anchor
+    # Resolve external URLs
+    if re.match(r'([a-z][a-z0-9+.\-]*:)?//', path, re.I):
+        return path
 
-    # Image URL: do the thing
+    # Resolve static assets
+    if path.startswith('@'):
+        return utils.static_url(path[1:], absolute)
+
+    path, sep, anchor = path.partition('#')
+
+    # Resolve entries
+    entry = utils.find_entry(path, search_path)
+    if entry:
+        return entry.permalink(absolute=absolute) + sep + anchor
+
+    # Resolve images and assets
     img_path, img_args, _ = image.parse_image_spec(path)
     img = image.get_image(img_path, search_path)
-    if isinstance(img, image.LocalImage):
+    if not isinstance(img, image.ImageNotFound):
         path, _ = img.get_rendition(**img_args)
-
-    return utils.remap_link_target(path, absolute)
+    return path + sep + anchor

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -118,8 +118,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
     def link(self, content, link, title=''):
         """ Emit a link, potentially remapped based on our embed or static rules """
 
-        link = links.remap_path(link, self._search_path,
-                                self._config.get('absolute'))
+        link = links.resolve(link, self._search_path,
+                             self._config.get('absolute'))
 
         return '{}{}</a>'.format(
             utils.make_tag('a', {

--- a/publ/model.py
+++ b/publ/model.py
@@ -14,7 +14,7 @@ db = orm.Database()  # pylint: disable=invalid-name
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 
 class GlobalConfig(db.Entity):
@@ -95,10 +95,14 @@ class Image(db.Entity):
     """ Image metadata """
     file_path = orm.PrimaryKey(str)
     checksum = orm.Required(str)
-    width = orm.Required(int)
-    height = orm.Required(int)
-    transparent = orm.Required(bool)
     fingerprint = orm.Required(str)
+
+    width = orm.Optional(int)
+    height = orm.Optional(int)
+    transparent = orm.Optional(bool)
+
+    is_asset = orm.Required(bool, default=False)
+    asset_name = orm.Optional(str, index=True)
 
 
 def setup():

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -367,3 +367,16 @@ def render_transparent_chit():
         "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7")
     return out_bytes, {'Content-Type': 'image/gif', 'ETag': 'chit',
                        'Last-Modified': 'Tue, 31 Jul 1990 08:00:00 -0000'}
+
+
+@orm.db_session(retry=5)
+def retrieve_asset(filename):
+    """ Retrieves a non-image asset associated with an entry """
+
+    record = model.Image.get(asset_name=filename)
+    if not record:
+        raise http_error.NotFound("File not found")
+    if not record.is_asset:
+        raise http_error.Forbidden()
+
+    return flask.send_file(record.file_path, conditional=True)


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Allows the use of assets that PIL doesn't support in both image and link contexts. Fixes #141.

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
If we try to resolve an image or a link to a file which isn't supported by PIL, the file gets indexed as an asset instead. If a file is indexed as an asset then it becomes retrievable via a URL like `_file/<shorthash>/<basename>`, which simply sends the file directly if it's been indexed as an asset.

This also ends up refactoring a lot of link handling stuff and makes for fewer weird paths things can go through. There are still a couple of places where `utils.remap_link_target` are called, but these can probably be refactored away in the future.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added a bunch of tests to publ-site; see https://github.com/PlaidWeb/publ-site/commit/66b7a049be5b7f8d4898dc89f7ec2d7a14072980

