### PR TITLE
Remove that Path-Unalias grodiness

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -254,6 +254,7 @@ def scan_file(fullpath, relpath):
         record = model.Category(**values)
 
     # update other relationships to the index
+    path_alias.remove_aliases(record)
     for alias in meta.get_all('Path-Alias', []):
         path_alias.set_alias(alias, category=record)
 

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -507,10 +507,9 @@ def scan_file(fullpath, relpath, assign_id):
         fixup_needed = True
 
     # add other relationships to the index
+    path_alias.remove_aliases(record)
     for alias in entry.get_all('Path-Alias', []):
         path_alias.set_alias(alias, entry=record)
-    for alias in entry.get_all('Path-Unalias', []):
-        path_alias.remove_alias(alias)
 
     if record.status == model.PublishStatus.DRAFT.value:
         logger.info("Not touching draft entry %s", fullpath)

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -33,8 +33,8 @@ def set_alias(alias, **kwargs):
         record.set(**values)
     else:
         record = model.PathAlias(**values)
-    orm.commit()
 
+    orm.commit()
     return record
 
 
@@ -47,6 +47,19 @@ def remove_alias(path):
     path -- the path to remove the alias of
     """
     orm.delete(p for p in model.PathAlias if p.path == path)
+    orm.commit()
+
+
+@orm.db_session
+def remove_aliases(target):
+    """ Remove all aliases to a destination """
+
+    if isinstance(target, model.Entry):
+        orm.delete(p for p in model.PathAlias if p.entry == target)
+    elif isinstance(target, model.Category):
+        orm.delete(p for p in model.PathAlias if p.category == target)
+    else:
+        raise TypeError("Unknown type {}".format(type(target)))
     orm.commit()
 
 

--- a/tests/content/aliases.md
+++ b/tests/content/aliases.md
@@ -1,0 +1,10 @@
+Title: Path alias modification
+Path-Alias: /path/alias/test
+xPath-Alias: /path/alias/test2
+Date: 2019-03-03 19:17:25-08:00
+Entry-ID: 674
+UUID: 2f5796c1-09a6-569b-b5fc-9763e0d6d5d7
+
+This should be visible from /path/alias/test
+
+but /path/alias/test2 should not be in the index


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #166 

<!-- Summary of the PR; please link to any issue(s) that this solves -->

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Instead of having to specify `Path-Unalias` to remove a path alias (which, incidentally, wasn't even being done on categories), Publ now just rebuilds all aliases when an entry or category file is scanned. 

It's a little inefficient (one extra database transaction per scanned file) but that's not that big a deal.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
No more need for `Path-Unalias`

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Made a test entry with two `Path-Alias` headers, looked for them in the database, removed one header, looked in the database.

## Got a site to show off?

<!-- If so, link to it here! -->
