### PR TITLE
Remove filters from unpaginated views

### DIFF
--- a/publ/view.py
+++ b/publ/view.py
@@ -69,8 +69,10 @@ class View:
                 break
 
         # pull in the first page type that appears
+        paginated = False
         for pagination in PAGINATION_PRIORITY:
             if pagination in input_spec:
+                paginated = True
                 spec[pagination] = input_spec[pagination]
                 break
 
@@ -78,7 +80,7 @@ class View:
 
         self.spec = spec
 
-        if 'start' in spec:
+        if 'start' in spec and paginated:
             if self._order_by == 'oldest':
                 self.spec['first'] = self.spec['start']
             elif self._order_by == 'newest':

--- a/tests/templates/tags/index.html
+++ b/tests/templates/tags/index.html
@@ -1,5 +1,3 @@
-{% set view = view(count=10) %}
-
 <h1>Tagging test</h1>
 
 <p>Spec: <code>{{view.spec}}</code></p>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Remove all pagination filters from unpaginated views; fixes #175 in the simplest way possible

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
If there's no pagination on a view that has a start offset, ignore the offset, since it makes no sense to have any sort of pagination in that case anyway (since any previous/next page would include all the content from the current page).

## Test plan

See changes to the tag tests, which are what exposed the problem in the first place.

## Got a site to show off?

<!-- If so, link to it here! -->
