### PR TITLE
Honor permissions on Path-Alias

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -536,8 +536,9 @@ def scan_file(fullpath, relpath, assign_id):
 
     # add other relationships to the index
     path_alias.remove_aliases(record)
-    for alias in entry.get_all('Path-Alias', []):
-        path_alias.set_alias(alias, entry=record)
+    if record.visible:
+        for alias in entry.get_all('Path-Alias', []):
+            path_alias.set_alias(alias, entry=record)
 
     with orm.db_session:
         set_tags = {

--- a/publ/model.py
+++ b/publ/model.py
@@ -74,6 +74,12 @@ class Entry(db.Entity):
     orm.composite_index(category, entry_type, local_date)
     orm.composite_index(category, entry_type, sort_title)
 
+    @property
+    def visible(self):
+        """ Returns true if the entry should be viewable """
+        return self.status not in (PublishStatus.DRAFT.value,
+                                   PublishStatus.GONE.value)
+
 
 class EntryTag(db.Entity):
     """ Tags for an entry """

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -77,7 +77,7 @@ def get_alias(path):
 
     template = record.template if record.template != 'index' else None
 
-    if record.entry:
+    if record.entry and record.entry.visible:
         if record.template:
             # a template was requested, so we go to the category page
             category = (record.category.category

--- a/tests/content/redirections/draft.md
+++ b/tests/content/redirections/draft.md
@@ -1,0 +1,9 @@
+Title: DRAFT entry
+Status: DRAFT
+Path-Alias: /redir/draft
+Redirect-To: http://example.com
+Date: 2019-04-04 06:37:37-07:00
+UUID: 5885b865-663b-5465-a0f8-bf120af24f12
+Entry-ID: 560
+
+This should not redirect.

--- a/tests/content/redirections/gone.md
+++ b/tests/content/redirections/gone.md
@@ -1,0 +1,9 @@
+Title: GONE entry
+Status: GONE
+Path-Alias: /redir/gone
+Redirect-To: http://example.com
+Date: 2019-04-04 06:37:37-07:00
+Entry-ID: 859
+UUID: 5885b865-663b-5465-a0f8-bf120af24f12
+
+This should not redirect.


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Respect the permissions of entries before following their Path-Alias; fixes #183

## Detailed description

When consulting an entry-based Path-Alias, treat an invisible entry as if the alias didn't exist.

## Test plan

See `draft.md` and `gone.md` in `tests/content/redirections`

## Got a site to show off?

<!-- If so, link to it here! -->
