### PR TITLE
Category tags

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -23,7 +23,7 @@ from . import caching
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-TagCount = collections.namedtuple('TagCount', ['tag', 'count'])
+TagCount = collections.namedtuple('TagCount', ['name', 'count'])
 
 
 @functools.lru_cache(10)

--- a/publ/category.py
+++ b/publ/category.py
@@ -61,16 +61,48 @@ class Category(caching.Memoizable):
             subcat_query = orm.select(c for c in subcat_query if c != '')
         self._subcats_recursive = subcat_query
 
-        self.link = utils.CallableProxy(self._link)
-
-        self.subcats = utils.CallableProxy(self._get_subcats)
-        self.first = utils.CallableProxy(self._first)
-        self.last = utils.CallableProxy(self._last)
-
         self._record = model.Category.get(category=path)
 
     def _key(self):
         return Category, self.path
+
+    @cached_property
+    def link(self):
+        """ Returns a link to the category.
+
+        Takes optional view arguments, as well as the following optional arguments:
+
+        template -- which template to generate the link against
+
+        """
+        return utils.CallableProxy(self._link)
+
+    @cached_property
+    def subcats(self):
+        """ Returns a list of subcategories.
+
+        Takes the following arguments:
+
+        recurse -- whether to include their subcategories as well (default: False)
+
+        """
+        return utils.CallableProxy(self._get_subcats)
+
+    @cached_property
+    def first(self):
+        """ Returns the first entry in the category.
+
+        Takes optional view arguments.
+        """
+        return utils.CallableProxy(self._first)
+
+    @cached_property
+    def last(self):
+        """ Returns the last entry in the category.
+
+        Takes optional view arguments.
+        """
+        return utils.CallableProxy(self._last)
 
     @cached_property
     def _meta(self):

--- a/tests/content/tags/subcat/subcat1.md
+++ b/tests/content/tags/subcat/subcat1.md
@@ -1,0 +1,10 @@
+Title: Subcategory entry
+Tag: foo
+Tag: moo
+Tag: hello
+Tag: meow
+Date: 2019-04-04 17:22:08-07:00
+Entry-ID: 933
+UUID: 0cd8fa96-ec22-5d88-b60d-43032f0233ff
+
+hi

--- a/tests/content/tags/subcat/subcat2.md
+++ b/tests/content/tags/subcat/subcat2.md
@@ -1,0 +1,8 @@
+Title: Subcategory entry 2
+Tag: hello
+Tag: meow
+Date: 2019-04-04 17:22:18-07:00
+Entry-ID: 491
+UUID: dc1fdc51-e13b-5ce8-aac2-b2ae9069132f
+
+hi

--- a/tests/templates/tags/browse.html
+++ b/tests/templates/tags/browse.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Tag browsing</title>
+</head>
+<body>
+
+    <h1>Tag browsing</h1>
+
+    <p><a href="{{view}}">back to index</a></p>
+
+    <h2>This level</h2>
+
+    <ul>
+        {% for name,count in category.tags|sort(attribute='count',reverse=True) %}
+        <li><a href="{{view(tag=name)}}">{{name}}</a> {{count}}
+            <ul>
+                {% for entry in view(tag=name).entries %}
+                <li><a href="{{entry.link}}">{{entry.title}}</a></li>
+                {% endfor %}
+            </ul>
+        </li>
+        {% endfor %}
+    </ul>
+
+    <h2>Recursive</h2>
+
+    <ul>
+        {% for name,count in category.tags(recurse=True)|sort(attribute='count',reverse=True) %}
+        <li><a href="{{view(tag=name)}}">{{name}}</a> {{count}}
+            <ul>
+                {% for entry in view(tag=name,recurse=True).entries %}
+                <li><a href="{{entry.link}}">{{entry.title}}</a></li>
+                {% endfor %}
+            </ul>
+        </li>
+        {% endfor %}
+    </ul>
+
+</body>
+</html>

--- a/tests/templates/tags/index.html
+++ b/tests/templates/tags/index.html
@@ -2,14 +2,7 @@
 
 <p>Spec: <code>{{view.spec}}</code></p>
 
-<p><a href="{{view(tag=None).link}}">clear all tags</a></p>
-
-<h2>Available tags:</h2>
-<ul>
-    {% for name,count in category.tags %}
-    <li><a href="{{view(tag=name)}}">{{name}}</a> ({{count}})</li>
-    {% endfor %}
-</ul>
+<p><a href="{{view(tag=None).link}}">clear all tags</a> <a href="browse">tag browser</a></p>
 
 <h2>Current tags: <code>{{view.tags}}</code></h2>
 
@@ -25,29 +18,17 @@
 {% if view.next %}<a href="{{view.next.link}}">next</a>{% endif %}
 </ul>
 
-{% set other = view(tag='foo') %}
-<h2><a href="{{other.link}}">Entries tagged <code>'foo'</code></a></h2>
+{% for restrict in ['foo',['hello','bar']] %}
+{% set other = view(tag=restrict,recurse=True) %}
+<h2>Entries tagged <a href="{{other}}"><code>{{restrict}}</code></a></h2>
 
 <ul>
 {% for entry in other.entries %}
 <li><a href="{{entry.link}}">{{entry.title}}</a>: <ul>
     {% for tag in entry.tags %}
-    <li><a href="{{view(tag=tag).link}}">{{ tag }}</a></li>
+    <li><a href="{{view(tag=tag)}}">{{ tag }}</a></li>
     {% endfor %}
 </ul></li>
 {% endfor %}
 </ul>
-
-{% set other = view(tag=('hello','bar')) %}
-<h2><a href="{{other.link}}">Entries tagged <code>'hello'</code> or <code>'bar'</code></a></h2>
-
-<ul>
-{% for entry in other.entries %}
-<li><a href="{{entry.link}}">{{entry.title}}</a>: <ul>
-    {% for tag in entry.tags %}
-    <li><a href="{{view(tag=tag).link}}">{{ tag }}</a></li>
-    {% endfor %}
-</ul></li>
 {% endfor %}
-</ul>
-

--- a/tests/templates/tags/index.html
+++ b/tests/templates/tags/index.html
@@ -4,6 +4,13 @@
 
 <p><a href="{{view(tag=None).link}}">clear all tags</a></p>
 
+<h2>Available tags:</h2>
+<ul>
+    {% for name,count in category.tags %}
+    <li><a href="{{view(tag=name)}}">{{name}}</a> ({{count}})</li>
+    {% endfor %}
+</ul>
+
 <h2>Current tags: <code>{{view.tags}}</code></h2>
 
 <ul>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #182 

## Detailed description

Rather than denormalize the category information on the tags, I realized that the category-based index would be enough. So this ended up being a lot easier than I thought.

I'm not terribly happy with the API being attached to `category` when it's really providing `view`-type functionality but that's what makes the most sense for the 99% case, anyway. If you really want to apply it at the view level you can do something like `category.root.tags(**view.spec)` although that's a bit ghastly.

## Test plan

Tests in the test site

## Got a site to show off?

<!-- If so, link to it here! -->
