### PR TITLE
Improve empty slug text

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -157,7 +157,7 @@ class Entry(caching.Memoizable):
         return flask.url_for('entry',
                              entry_id=self._record.id,
                              category=self._record.category if expand else None,
-                             slug_text=self._record.slug_text if expand else None,
+                             slug_text=self._record.slug_text if expand and self._record.slug_text else None,
                              _external=absolute,
                              **kwargs)
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -318,7 +318,7 @@ def render_entry(entry_id, slug_text='', category=''):
         return redirect(url_for('entry',
                                 entry_id=entry_id,
                                 category=record.category,
-                                slug_text=record.slug_text))
+                                slug_text=record.slug_text if record.slug_text else None))
 
     # if the entry canonically redirects, do that now
     entry_redirect = record.redirect_url

--- a/tests/content/empty slug text.md
+++ b/tests/content/empty slug text.md
@@ -8,4 +8,4 @@ This entry should be viewable even with its empty slug text.
 
 .....
 
-Presumably it will work <a href="/557-">with</a> or <a href="/557">without</a> the -. The default link should be without.
+Presumably it will work <a href="/557-">with</a> or <a href="/557">without</a> the -. The default link should be without, as should a redirection to <a href="/557-kasdjflaskja">the incorrect slug</a>.

--- a/tests/content/empty slug text.md
+++ b/tests/content/empty slug text.md
@@ -1,5 +1,5 @@
 Title: Empty slug text
-Slug-Text: 
+Slug-Text:
 Date: 2019-01-23 20:56:13-08:00
 Entry-ID: 557
 UUID: 9923c01c-4737-5201-94d2-8f67420df3b8
@@ -8,4 +8,4 @@ This entry should be viewable even with its empty slug text.
 
 .....
 
-Presumably it will work with or without the -. Let's see!
+Presumably it will work <a href="/557-">with</a> or <a href="/557">without</a> the -. The default link should be without.


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

If an entry has empty slug text, don't put the `-` into the URL

## Test plan

updated localhost:5000/557; the trailing `-` is still allowed (mostly because fixing that would be tricky), but any generated permalinks or redirections should now go without.

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
