### PR TITLE
Fix support for HTML entities

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -157,7 +157,9 @@ class Entry(caching.Memoizable):
         return flask.url_for('entry',
                              entry_id=self._record.id,
                              category=self._record.category if expand else None,
-                             slug_text=self._record.slug_text if expand and self._record.slug_text else None,
+                             slug_text=self._record.slug_text
+                             if expand and self._record.slug_text
+                             else None,
                              _external=absolute,
                              **kwargs)
 

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -37,6 +37,12 @@ class HTMLEntry(utils.HTMLTransform):
     def handle_charref(self, name):
         self.append('&#' + name + ';')
 
+    def handle_decl(self, decl):
+        LOGGER.warning("handle_decl: '%s'", decl)
+
+    def handle_pi(self, data):
+        LOGGER.warning("handle_pi: '%s'", data)
+
     def handle_comment(self, data):
         self.append('<!--' + data + '-->')
 
@@ -120,8 +126,5 @@ def process(text, config, search_path):
     processor = HTMLEntry(config, search_path)
     processor.feed(text)
     text = processor.get_data()
-
-    if not config.get('no_smartquotes'):
-        text = misaka.smartypants(text)
 
     return flask.Markup(text)

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -31,6 +31,15 @@ class HTMLEntry(utils.HTMLTransform):
         """ Handle an end tag """
         self.append('</' + tag + '>')
 
+    def handle_entityref(self, name):
+        self.append('&' + name + ';')
+
+    def handle_charref(self, name):
+        self.append('&#' + name + ';')
+
+    def handle_comment(self, data):
+        self.append('<!--' + data + '-->')
+
     def handle_startendtag(self, tag, attrs):
         """ Handle a self-closing tag """
         self._handle_tag(tag, attrs, True)

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -3,7 +3,6 @@
 
 import logging
 
-import misaka
 import flask
 
 from . import utils, links, image

--- a/tests/content/html entities etc.html
+++ b/tests/content/html entities etc.html
@@ -1,0 +1,16 @@
+Title: HTML entities
+Date: 2019-05-07 20:44:36-07:00
+Entry-ID: 380
+UUID: eb1157c5-0251-5e3a-84ff-20df7de27b82
+
+<p>Foo & bar are invalid.</p>
+
+<p>Foo &amp; bar are happy.</p>
+
+<p>Foo &#62; bar.</p>
+
+<!-- Psst! Over here! -->
+
+<p><a href="/?a=b&c=d">technically an invalid URL</a>; it should look like <a href="/?a=b&amp;c=d">this</a>. (Looks like it gets rewritten correctly! Cool!)</p>
+
+<p>&amp;ersands are hard. &amp;amp;</p>

--- a/tests/content/relative entry links.md
+++ b/tests/content/relative entry links.md
@@ -7,15 +7,15 @@ Some links to entries on a relative basis
 
 .....
 
-How about the [image test](image test.md)?
+How about the [image test](images/image renditions.md)?
 
 Or maybe the [bullet number test](markdown-titles/bullet number.md)?
 
 Does it work if it's in a [different category](differentcat.md)?
 
-How about a [parent directory](../blog/catpics/cat pictures.md)?
+How about a [parent directory](../content/html-links.html)?
 
-Or something [relative to root](/blog/20180408 links.md)?
+Or something [relative to root](/images/exif orientations.md)?
 
 What about [by entry ID](325)?
 
@@ -23,4 +23,4 @@ And what if [nothing is found](asdlkfjsalfj)?
 
 Of course [external links should still work](http://beesbuzz.biz/), even if they're [protocol-relative](//beesbuzz.biz).
 
-So should [internal absolute links](/blog/).
+So should [internal absolute links](/images/).


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #198 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Previously there was no handling of comments, entities, or charrefs. Which was causing them to get eaten. Oops.

This also disables smartypants on plain HTML entries because

1. smartypants was adding an extra level of `\` processing for some reason
2. HTML entries are supposed to be minimally-processed anyway


## Test plan

tests added to repo

## Got a site to show off?

<!-- If so, link to it here! -->
