### PR TITLE
Forward absolute parameter to asset link resolver

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -198,10 +198,10 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
-                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
+                "sha256:31cba6ffb739f099a85e243eff8cb717089fdd3c7300767d9fc34cb8e1b065f5",
+                "sha256:5ad302949b3c98dd73f8d9fcdc7e9cb592f120e32a18e23efd7f3dc51194472b"
             ],
-            "version": "==2.3.1"
+            "version": "==2.4.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -387,10 +387,10 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
-                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
+                "sha256:31cba6ffb739f099a85e243eff8cb717089fdd3c7300767d9fc34cb8e1b065f5",
+                "sha256:5ad302949b3c98dd73f8d9fcdc7e9cb592f120e32a18e23efd7f3dc51194472b"
             ],
-            "version": "==2.3.1"
+            "version": "==2.4.0"
         },
         "pylint": {
             "hashes": [

--- a/publ/links.py
+++ b/publ/links.py
@@ -29,5 +29,5 @@ def resolve(path, search_path, absolute=False):
     img_path, img_args, _ = image.parse_image_spec(path)
     img = image.get_image(img_path, search_path)
     if not isinstance(img, image.ImageNotFound):
-        path, _ = img.get_rendition(**img_args, absolute=absolute)
+        path, _ = img.get_rendition(**{**img_args, 'absolute': absolute})
     return path + sep + anchor

--- a/publ/links.py
+++ b/publ/links.py
@@ -29,5 +29,5 @@ def resolve(path, search_path, absolute=False):
     img_path, img_args, _ = image.parse_image_spec(path)
     img = image.get_image(img_path, search_path)
     if not isinstance(img, image.ImageNotFound):
-        path, _ = img.get_rendition(**img_args)
+        path, _ = img.get_rendition(**img_args, absolute=absolute)
     return path + sep + anchor


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #201 by forwarding the `absolute` argument along to the asset link resolver

## Detailed description

When I rewrote how asset links resolve I neglected to notice that the new argument parsing stuff wasn't actually forwarding `absolute` along. Now it does.

## Test plan

`curl localhost:5000/feed?id=315` to verify asset links are being rewritten correctly.
