### PR TITLE
Fix default error handler

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -329,33 +329,33 @@
         },
         "isort": {
             "hashes": [
-                "sha256:1349c6f7c2a0f7539f5f2ace51a9a8e4a37086ce4de6f78f5f53fb041d0a3cd5",
-                "sha256:f09911f6eb114e5592abe635aded8bf3d2c3144ebcfcaf81ee32e7af7b7d1870"
+                "sha256:49293e2ff590cc8d48bc1f51970548b5b102bf038439ca1af77f352164725628",
+                "sha256:ba69a4be8474be11720636bc2f0cf66f7054d417d4c1dbc1dfe504bb8e739541"
             ],
-            "version": "==4.3.18"
+            "version": "==4.3.19"
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:118d53f8819f9457732dd0e418752f2850f395c5405b2e12485f52336e4ad0f5",
-                "sha256:495c583b363c3eded649e2c00177093f03f856f5c9f95b527420084a9ce17b9d",
-                "sha256:55fa9eab93482891ce97473e63610efdd9c8fa5c05cca9f60468c412e602e499",
-                "sha256:642fc0a9b61920669dab66e400f79f1b8b0e8f698dcde85f7e9ae5528dbcaf4a",
-                "sha256:7003959a170fde9b92936c38562810f94679c80608fb4b007e026b915bef8b27",
-                "sha256:7e63da94f5a1ddb0d2dcdb5d17ff4d1d33f51f3368bdf0475d5f56c0f3b99592",
-                "sha256:7fb11d33d99a374e4b0c3fb20128890b9cf784ca7e4b91ecbb191d34618bd9fe",
-                "sha256:8758715ea005afa293783797498d64f40ab14d1ded208b3e282760cde9512f1d",
-                "sha256:8995543f47a8b81962e384f12791114af9f4997be7a0db71abc40d2a2dfee961",
-                "sha256:91c7e1316116fedda36818ce7cd269378fffc4219781536eff441ea1e68e1caf",
-                "sha256:9b41ec246d31ca6a840dcf67673b2668adc5a095c64310d26d73292588563ea3",
-                "sha256:a8be3cfd7c3154e8d39276c627c5e7ee55d1f2094597b060ece99620ef9fe86b",
-                "sha256:afcab74f471652b643900e0862b31892ac5fe5a75e435b786a1825855f4effdf",
-                "sha256:d49a90c27074f44c8dc147d83e31140523948ee147b3248634c540e053caea58",
-                "sha256:d6957cadc9c079ef4697564af500d52fba6d14fb2f08d20ce92f52201fb77050",
-                "sha256:da7f2a6c82a11dc4e05bab73522f0d6dd4f3bbc8378cd4b0769137f342cdb3f0",
-                "sha256:f03a21f6f6e54778860122a620f70c8b148ec4ee175968782bcaaa94955a46f9",
-                "sha256:f6c718ffca055852479880debbe717da952fcfd60067a0ddb6fe3b053b1d4de0"
+                "sha256:159a745e61422217881c4de71f9eafd9d703b93af95618635849fe469a283661",
+                "sha256:23f63c0821cc96a23332e45dfaa83266feff8adc72b9bcaef86c202af765244f",
+                "sha256:3b11be575475db2e8a6e11215f5aa95b9ec14de658628776e10d96fa0b4dac13",
+                "sha256:3f447aff8bc61ca8b42b73304f6a44fa0d915487de144652816f950a3f1ab821",
+                "sha256:4ba73f6089cd9b9478bc0a4fa807b47dbdb8fad1d8f31a0f0a5dbf26a4527a71",
+                "sha256:4f53eadd9932055eac465bd3ca1bd610e4d7141e1278012bd1f28646aebc1d0e",
+                "sha256:64483bd7154580158ea90de5b8e5e6fc29a16a9b4db24f10193f0c1ae3f9d1ea",
+                "sha256:6f72d42b0d04bfee2397aa1862262654b56922c20a9bb66bb76b6f0e5e4f9229",
+                "sha256:7c7f1ec07b227bdc561299fa2328e85000f90179a2f44ea30579d38e037cb3d4",
+                "sha256:7c8b1ba1e15c10b13cad4171cfa77f5bb5ec2580abc5a353907780805ebe158e",
+                "sha256:8559b94b823f85342e10d3d9ca4ba5478168e1ac5658a8a2f18c991ba9c52c20",
+                "sha256:a262c7dfb046f00e12a2bdd1bafaed2408114a89ac414b0af8755c696eb3fc16",
+                "sha256:acce4e3267610c4fdb6632b3886fe3f2f7dd641158a843cf6b6a68e4ce81477b",
+                "sha256:be089bb6b83fac7f29d357b2dc4cf2b8eb8d98fe9d9ff89f9ea6012970a853c7",
+                "sha256:bfab710d859c779f273cc48fb86af38d6e9210f38287df0069a63e40b45a2f5c",
+                "sha256:c10d29019927301d524a22ced72706380de7cfc50f767217485a912b4c8bd82a",
+                "sha256:dd6e2b598849b3d7aee2295ac765a578879830fb8966f70be8cd472e6069932e",
+                "sha256:e408f1eacc0a68fed0c08da45f31d0ebb38079f043328dce69ff133b95c29dc1"
             ],
-            "version": "==1.4.0"
+            "version": "==1.4.1"
         },
         "mccabe": {
             "hashes": [
@@ -430,10 +430,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:d385c95361699e5cf7622485d9b9eae2d4864b21cd5a2374a9c381ffed701021",
-                "sha256:e22977e3ebe961f72362f6ddfb9197cc531c9737aaf5f607ef09740c849ecd05"
+                "sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab",
+                "sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b"
             ],
-            "version": "==4.31.1"
+            "version": "==4.32.1"
         },
         "twine": {
             "hashes": [

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -185,7 +185,10 @@ def render_error(category, error_message, error_codes, exception=None):
 
 def render_exception(error):
     """ Catch-all renderer for the top-level exception handler """
-    category = '/'.join(request.path.split('/')[1:-1])
+
+    # Effectively strip off the leading '/', and let map_template decide
+    # what the actual category is
+    _, _, category = request.path.partition('/')
 
     qsize = index.queue_length()
     if isinstance(error, http_error.NotFound) and qsize:

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -22,7 +22,7 @@ from . import view
 from . import caching
 from .caching import cache
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+LOGGER = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 # mapping from template extension to MIME type; probably could be better
 EXTENSION_MAP = {
@@ -146,6 +146,8 @@ def render_error(category, error_message, error_codes, exception=None):
     exception -- Any exception that led to this error page
     """
 
+    LOGGER.info('category=%s', category)
+
     if isinstance(error_codes, int):
         error_codes = [error_codes]
 
@@ -163,18 +165,39 @@ def render_error(category, error_message, error_codes, exception=None):
             error={'code': error_code, 'message': error_message},
             exception=exception)[0], error_code
 
-    # no template found, so fall back to default Flask handler
-    return flask.abort(error_code)
+    # no template found, so fall back to a default
+    if exception and 'str' in exception:
+        message = exception['str']
+    else:
+        message = "An unknown error occurred"
+    return """<!DOCTYPE html>
+<html>
+<head><title>{code} {error}</title></head>
+<body>
+<h1>{error}</h1>
+<p>{message}</p>
+<hr><address><a href="http://publ.beesbuzz.biz">Publ</a> at {url}</address>
+</body></html>""".format(code=error_code,
+                         error=error_message,
+                         message=message,
+                         url=request.url), error_code
 
 
 def render_exception(error):
     """ Catch-all renderer for the top-level exception handler """
-    _, _, category = str.partition(request.path, '/')
+    category = '/'.join(request.path.split('/')[1:-1])
 
     qsize = index.queue_length()
     if isinstance(error, http_error.NotFound) and qsize:
         response = flask.make_response(render_error(
-            category, "Site reindex in progress (qs={})".format(qsize), 503))
+            category,
+            "Site reindex in progress",
+            503,
+            {
+                'type': 'Service Unavailable',
+                'str': "The site's contents are not fully known; please try again later",
+                'args': {'qs': qsize}
+            }))
         response.headers['Retry-After'] = qsize
         response.headers['Refresh'] = max(5, qsize / 5)
         return response, 503
@@ -239,14 +262,15 @@ def render_category(category='', template=None):
     if not tmpl:
         # this might actually be a malformed category URL
         test_path = '/'.join((category, template)) if category else template
-        logger.debug("Checking for malformed category %s", test_path)
+        LOGGER.debug("Checking for malformed category %s", test_path)
         record = orm.select(
             e for e in model.Entry if e.category == test_path).exists()
         if record:
             return redirect(url_for('category', category=test_path, **request.args))
 
         # nope, we just don't know what this is
-        raise http_error.NotFound("No such view")
+        raise http_error.NotFound(
+            "No such view '{template}'".format(template=template))
 
     view_spec = view.parse_view_spec(request.args)
     view_spec['category'] = category
@@ -286,7 +310,7 @@ def render_entry(entry_id, slug_text='', category=''):
         if path_redirect:
             return path_redirect
 
-        logger.info("Attempted to retrieve nonexistent entry %d", entry_id)
+        LOGGER.info("Attempted to retrieve nonexistent entry %d", entry_id)
         raise http_error.NotFound("No such entry")
 
     # see if the file still exists

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -146,7 +146,11 @@ def render_error(category, error_message, error_codes, exception=None):
     exception -- Any exception that led to this error page
     """
 
-    LOGGER.info('category=%s', category)
+    LOGGER.info("Rendering error: category=%s error_message='%s' error_codes=%s exception=%s",
+                category,
+                error_message,
+                error_codes,
+                exception)
 
     if isinstance(error_codes, int):
         error_codes = [error_codes]
@@ -199,7 +203,7 @@ def render_exception(error):
             {
                 'type': 'Service Unavailable',
                 'str': "The site's contents are not fully known; please try again later",
-                'args': {'qs': qsize}
+                'qsize': qsize
             }))
         response.headers['Retry-After'] = qsize
         response.headers['Refresh'] = max(5, qsize / 5)

--- a/tests/content/err/failure.md
+++ b/tests/content/err/failure.md
@@ -1,0 +1,6 @@
+Title: failure
+Date: 2019-05-13 20:57:39-07:00
+Entry-ID: 724
+UUID: f003e67a-c3e8-5f91-8ae1-f4def03843f1
+
+This category's index should not work. In prod it should show a pretty error page, in debug it should show the exception handler.

--- a/tests/templates/err/error.html
+++ b/tests/templates/err/error.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{error.code}} {{error.message}}</title>
+</head>
+<body>
+    <h1>{{error.message}}</h1>
+
+    <div id="errorinfo"><ul>
+        <li><span>error</span> {{error.code}} {{error.message}}</li>
+        <li><span>request time</span> {{arrow.now().format()}}</li>
+        <li><span>url</span> <code>{{request.url}}</code></li>
+        <li><span>path</span> <code>{{request.path}}</code></li>
+        <li><span>full_path</span> <code>{{request.full_path}}</code></li>
+        <li><span>endpoint</span> <code>{{request.endpoint}}</code></li>
+        <li><span>url_rule</span> <code>{{request.url_rule}}</code></li>
+    {% if exception %}
+        <li><span>Exception information</span> {{exception.type}}: {{exception.str}}</li>
+    {% endif %}
+    </ul></div>
+
+</body></html>
+

--- a/tests/templates/err/error.html
+++ b/tests/templates/err/error.html
@@ -16,7 +16,11 @@
         <li><span>endpoint</span> <code>{{request.endpoint}}</code></li>
         <li><span>url_rule</span> <code>{{request.url_rule}}</code></li>
     {% if exception %}
-        <li><span>Exception information</span> {{exception.type}}: {{exception.str}}</li>
+        <li><span>Exception information</span>:<ul>
+            {% for key,val in exception.items() %}
+            <li><code>{{key}}</code>: <code>{{val}}</code></li>
+            {% endfor %}
+        </ul></li>
     {% endif %}
     </ul></div>
 

--- a/tests/templates/err/index.html
+++ b/tests/templates/err/index.html
@@ -1,0 +1,1 @@
+{% this should fail %}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Show a default error page if no error template is provided; Fixes #135 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
It's unclear where the default Flask error handler actually comes from or how to trigger it (`flask.abort()` simply throws an `HTTPException` which causes an exception loop) so instead we embed a simple template into Publ itself. This has the benefit of providing slightly more information anyway.

## Test plan

Used `./runTests.sh` to check the following URLs:

```
http://localhost:5000/asdf
http://localhost:5000/error
http://localhost:5000/err/
http://localhost:5000/2348242
http://localhost:5000/err/2348242
```

Used `pipenv run python3 ./tests.py` to run in prod and checked the same URLs. In particular, `/err/` should show the `templates/err/error.html` template in production but still show a stack trace in test.

## Got a site to show off?

<!-- If so, link to it here! -->
