### PR TITLE
Fix discarded entities and charrefs

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -192,7 +192,7 @@ class Entry(caching.Memoizable):
         """ Get the title of the entry. Accepts the following argument:
 
         markup -- If True, convert it from Markdown to HTML; otherwise, strip
-            all markdown (default: True)
+            all markup (default: True)
         """
         return CallableProxy(self._title)
 

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -30,12 +30,6 @@ class HTMLEntry(utils.HTMLTransform):
         """ Handle an end tag """
         self.append('</' + tag + '>')
 
-    def handle_entityref(self, name):
-        self.append('&' + name + ';')
-
-    def handle_charref(self, name):
-        self.append('&#' + name + ';')
-
     def handle_decl(self, decl):
         LOGGER.warning("handle_decl: '%s'", decl)
 

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -296,6 +296,12 @@ class HTMLTransform(html.parser.HTMLParser):
         """ Concatenate the output """
         return ''.join(self._fed)
 
+    def handle_entityref(self, name):
+        self.append('&' + name + ';')
+
+    def handle_charref(self, name):
+        self.append('&#' + name + ';')
+
     def error(self, message):
         """ Deprecated, per https://bugs.python.org/issue31844 """
         return message


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #206 by not discarding entities and charrefs in default document transforms

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

Moved the entityref and charref handlers out of the HTMLEntry parser and into the base HTMLTransform class.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
see `tests/content/apostrophe titles.md`

