### PR TITLE
Properly absolute-ify unresolved HREFs

### DIFF
--- a/publ/links.py
+++ b/publ/links.py
@@ -2,6 +2,9 @@
 """ Functions for manipulating outgoing HTML links """
 
 import re
+from urllib.parse import urljoin
+
+from flask import request
 
 from . import image
 from . import utils
@@ -30,4 +33,9 @@ def resolve(path, search_path, absolute=False):
     img = image.get_image(img_path, search_path)
     if not isinstance(img, image.ImageNotFound):
         path, _ = img.get_rendition(**{**img_args, 'absolute': absolute})
+
+    # We don't know what this is, so just treat it like a normal URL.
+    if absolute:
+        path = urljoin(request.url, path)
+
     return path + sep + anchor

--- a/tests/content/aliases.md
+++ b/tests/content/aliases.md
@@ -4,7 +4,8 @@ xPath-Alias: /path/alias/test2
 Date: 2019-03-03 19:17:25-08:00
 Entry-ID: 674
 UUID: 2f5796c1-09a6-569b-b5fc-9763e0d6d5d7
+Last-Modified: 2019-06-23 16:44:38+00:00
 
-This should be visible from /path/alias/test
+This should be visible from [/path/alias/test](/path/alias/test)
 
 but /path/alias/test2 should not be in the index


### PR DESCRIPTION
## Summary

Fixes #212 

## Detailed description

Path-aliases remain unresolved. Now the resolver will absoluteify unresolved links too.

## Test plan

Modified test id 674 (`aliases.md`), and tested correct result with:

    curl localhost:5000/feed?id=674

