### PR TITLE
Feature/215 arg memoization

### DIFF
--- a/publ/view.py
+++ b/publ/view.py
@@ -6,7 +6,7 @@ import flask
 from werkzeug.utils import cached_property
 from pony import orm
 
-from . import model, utils, queries
+from . import model, utils, queries, caching
 from .entry import Entry
 
 # Prioritization list for pagination
@@ -43,7 +43,7 @@ SPAN_FORMATS = {
 }
 
 
-class View:
+class View(caching.Memoizable):
     # pylint: disable=too-many-instance-attributes,too-few-public-methods
     """ A view of entries """
 
@@ -101,8 +101,8 @@ class View:
         else:
             self.type = None
 
-    def __repr__(self):
-        return repr(self.spec)
+    def _key(self):
+        return View, repr(self.spec)
 
     def __str__(self):
         return str(self._link())

--- a/tests.py
+++ b/tests.py
@@ -20,6 +20,10 @@ config = {
     'template_folder': 'tests/templates',
     'static_folder': 'tests/static',
     'cache': {
+        'CACHE_TYPE': 'simple',
+        'CACHE_DEFAULT_TIMEOUT': 600,
+        'CACHE_THRESHOLD': 20
+    } if os.environ.get('TEST_CACHING') else {
         'CACHE_NO_NULL_WARNING': True
     },
 }

--- a/tests.py
+++ b/tests.py
@@ -8,7 +8,7 @@ import publ.image
 
 APP_PATH = os.path.dirname(os.path.abspath(__file__))
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 config = {
     # Leave this off to do an in-memory database

--- a/tests/templates/custom-args.html
+++ b/tests/templates/custom-args.html
@@ -1,0 +1,18 @@
+{#
+
+This template is for testing the cacheability of templates which make use of
+custom request.args, for issue https://github.com/PlaidWeb/Publ/issues/215
+
+To test it, set the TEST_CACHING environment variable e.g.
+
+TEST_CACHING=1 ./runTests.sh
+
+#}<!DOCTYPE html>
+<html><head>
+<title>{{ request.args.title or "no title specified"}}</title>
+</head><body>
+<h1>{{request.args.title or "no title specified"}}</h1>
+
+<p>{{request.args.body or "no body specified"}}</p>
+</body>
+</html>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Include request.args as the template render memoization; fixes #215 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Originally I was going to do an overly-complicated thing to have the template keep track of the request.args keys that are actually used and make that part of the cache memoization, but that had a few edge cases I wasn't happy with and then I realized that it doesn't matter in a DoS situation if people can just spam the arg *value* anyway. So I took the easier approach of just making `request.args` be part of the cache key for template renders anyway.

## Test plan

Added `tests/templates/custom-args.html` which can test this.

Before: making requests to `/custom-args?title=foo&body=bar` would cause subsequent renders of `/custom-args` to be cached with those values, even if the arguments change.

After: making requests with different values will change the values; the Flask log however shows that only the first pageview results in a render, e.g.:

```
DEBUG:publ.rendering:Rendering template custom-args with args ImmutableMultiDict([('a', 'b'), ('c', 'd')]) and kwargs {'_url_root': 'http://localhost:5000/', 'category': (<class 'publ.category.Category'>, ''), 'view': (<class 'publ.view.View'>, "{'category': ''}")}
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:28] "GET /custom-args?a=b&c=d HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:29] "GET /custom-args?a=b&c=d HTTP/1.1" 200 -
DEBUG:publ.rendering:Rendering template custom-args with args ImmutableMultiDict([('a', 'b'), ('c', 'd'), ('e', 'f')]) and kwargs {'_url_root': 'http://localhost:5000/', 'category': (<class 'publ.category.Category'>, ''), 'view': (<class 'publ.view.View'>, "{'category': ''}")}
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:33] "GET /custom-args?a=b&c=d&e=f HTTP/1.1" 200 -
DEBUG:publ.rendering:Rendering template custom-args with args ImmutableMultiDict([]) and kwargs {'_url_root': 'http://localhost:5000/', 'category': (<class 'publ.category.Category'>, ''), 'view': (<class 'publ.view.View'>, "{'category': ''}")}
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:37] "GET /custom-args HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:43] "GET /custom-args HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:43] "GET /custom-args HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:45] "GET /custom-args HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:46] "GET /custom-args HTTP/1.1" 200 -
DEBUG:publ.rendering:Rendering template custom-args with args ImmutableMultiDict([('title', 'foo')]) and kwargs {'_url_root': 'http://localhost:5000/', 'category': (<class 'publ.category.Category'>, ''), 'view': (<class 'publ.view.View'>, "{'category': ''}")}
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:52] "GET /custom-args?title=foo HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:54] "GET /custom-args?title=foo HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:54] "GET /custom-args?title=foo HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [27/Jun/2019 16:14:54] "GET /custom-args?title=foo HTTP/1.1" 200 -
```

Additionally, going through the browser history still has 304 responses being generated correctly as appropriate.
