### PR TITLE
Refactor CallableProxy call sites

### DIFF
--- a/publ/cards.py
+++ b/publ/cards.py
@@ -5,7 +5,7 @@ import logging
 
 import misaka
 
-from . import image, config
+from . import image, config, utils
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -19,7 +19,7 @@ class CardData():
         self.images = []
 
 
-class CardParser(misaka.BaseRenderer):
+class MarkdownCardParser(misaka.BaseRenderer):
     """ Customized Markdown renderer for parsing out information for a card """
 
     def __init__(self, out, args, image_search_path):
@@ -86,14 +86,42 @@ class CardParser(misaka.BaseRenderer):
 
         return None
 
+class HtmlCardParser(utils.HTMLTransform):
+    """ Parse the first paragraph out of an HTML document """
+    def __init__(self, card):
+        super().__init__()
 
-def extract_card(text, args, image_search_path):
+        self._consume = True
+        self._card = card
+
+    def handle_starttag(self, tag, attrs):
+        # pylint:disable=unused-argument
+        if tag == 'p' and self._card.description:
+            # We already got some data, so this is a malformed/old-style document
+            self._consume = False
+
+    def handle_endtag(self, tag):
+        if tag == 'p':
+            self._consume = False
+
+    def handle_data(self, data):
+        if self._consume:
+            if not self._card.description:
+                self._card.description = ''
+            self._card.description += data
+
+
+def extract_card(text, is_markdown, args, image_search_path):
     """ Extract card data based on the provided texts. """
     card = CardData()
-    parser = CardParser(card, args, image_search_path)
-    misaka.Markdown(parser,
-                    extensions=args.get('markdown_extensions')
-                    or config.markdown_extensions
-                    )(text)
+    if is_markdown:
+        parser = MarkdownCardParser(card, args, image_search_path)
+        misaka.Markdown(parser,
+                        extensions=args.get('markdown_extensions')
+                        or config.markdown_extensions
+                        )(text)
+    else:
+        parser = HtmlCardParser(card)
+        parser.feed(text)
 
     return card

--- a/publ/cards.py
+++ b/publ/cards.py
@@ -86,8 +86,10 @@ class MarkdownCardParser(misaka.BaseRenderer):
 
         return None
 
+
 class HtmlCardParser(utils.HTMLTransform):
     """ Parse the first paragraph out of an HTML document """
+
     def __init__(self, card):
         super().__init__()
 

--- a/publ/category.py
+++ b/publ/category.py
@@ -277,7 +277,6 @@ class Category(caching.Memoizable):
         return queries.build_query({**spec, 'category': self})
 
 
-
 @orm.db_session(immediate=True)
 def scan_file(fullpath, relpath):
     """ scan a file and put it into the index """

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -79,7 +79,15 @@ class Entry(caching.Memoizable):
     def link(self):
         """ Get a link to this entry. Accepts the same parameters as permalink;
         may be pre-redirected. """
-        return CallableProxy(self._link)
+        def _link(*args, **kwargs):
+            """ Returns a link, potentially pre-redirected """
+            if self._record.redirect_url:
+                return links.resolve(self._record.redirect_url,
+                                     self.search_path, kwargs.get('absolute'))
+
+            return self.permalink(*args, **kwargs)
+
+        return CallableProxy(_link)
 
     @cached_property
     def permalink(self):
@@ -89,7 +97,17 @@ class Entry(caching.Memoizable):
         expand -- if True, expands the link to include the category and slug text;
             if False, it will only be the entry ID (default: True)
         """
-        return CallableProxy(self._permalink)
+        def _permalink(absolute=False, expand=True, **kwargs):
+            return flask.url_for('entry',
+                                 entry_id=self._record.id,
+                                 category=self._record.category if expand else None,
+                                 slug_text=self._record.slug_text
+                                 if expand and self._record.slug_text
+                                 else None,
+                                 _external=absolute,
+                                 **kwargs)
+
+        return CallableProxy(_permalink)
 
     @cached_property
     def archive(self):
@@ -105,7 +123,31 @@ class Entry(caching.Memoizable):
         category -- Which category to generate the link against (default: the entry's category)
         template -- Which template to generate the link for
         """
-        return CallableProxy(self._archive_link)
+        def _archive_link(paging=None, template='', category=None, absolute=False, tag=None):
+            # pylint:disable=too-many-arguments
+            args = {
+                'template': template,
+                'category': category if category is not None else self.category,
+            }
+            if paging == 'day':
+                args['date'] = self.date.format(utils.DAY_FORMAT)
+            elif paging == 'month':
+                args['date'] = self.date.format(utils.MONTH_FORMAT)
+            elif paging == 'year':
+                args['date'] = self.date.format(utils.YEAR_FORMAT)
+            elif paging == 'week':
+                args['date'] = self.date.span('week')[0].format(utils.WEEK_FORMAT)
+            elif paging == 'offset' or not paging:
+                args['id'] = self._record.id
+            else:
+                raise ValueError("Unknown paging type '{}'".format(paging))
+
+            if tag:
+                args['tag'] = tag
+
+            return flask.url_for('category', **args, _external=absolute)
+
+        return CallableProxy(_archive_link)
 
     @cached_property
     def type(self):
@@ -128,7 +170,19 @@ class Entry(caching.Memoizable):
 
         Accepts view parameters as arguments.
         """
-        return CallableProxy(self._next)
+        def _next(**kwargs):
+            """ Get the next item in any particular category """
+            spec = self._pagination_default_spec(kwargs)
+            spec.update(kwargs)
+
+            query = queries.build_query(spec)
+            query = queries.where_after_entry(query, self._record)
+
+            for record in query.order_by(model.Entry.local_date,
+                                         model.Entry.id)[:1]:
+                return Entry(record)
+            return None
+        return CallableProxy(_next)
 
     @cached_property
     def previous(self):
@@ -136,56 +190,25 @@ class Entry(caching.Memoizable):
 
         Accepts view parameters as arguments.
         """
-        return CallableProxy(self._previous)
+        def _previous(**kwargs):
+            """ Get the previous item in any particular category """
+            spec = self._pagination_default_spec(kwargs)
+            spec.update(kwargs)
+
+            query = queries.build_query(spec)
+            query = queries.where_before_entry(query, self._record)
+
+            for record in query.order_by(orm.desc(model.Entry.local_date),
+                                         orm.desc(model.Entry.id))[:1]:
+                return Entry(record)
+            return None
+        return CallableProxy(_previous)
 
     @cached_property
     def category(self):
         """ Get the category this entry belongs to. """
         from .category import Category  # pylint: disable=cyclic-import
         return Category(self._record.category)
-
-    def _link(self, *args, **kwargs):
-        """ Returns a link, potentially pre-redirected """
-        if self._record.redirect_url:
-            return links.resolve(self._record.redirect_url,
-                                 self.search_path, kwargs.get('absolute'))
-
-        return self._permalink(*args, **kwargs)
-
-    def _permalink(self, absolute=False, expand=True, **kwargs):
-        """ Returns a canonical URL for the item """
-        return flask.url_for('entry',
-                             entry_id=self._record.id,
-                             category=self._record.category if expand else None,
-                             slug_text=self._record.slug_text
-                             if expand and self._record.slug_text
-                             else None,
-                             _external=absolute,
-                             **kwargs)
-
-    def _archive_link(self, paging=None, template='', category=None, absolute=False, tag=None):
-        # pylint:disable=too-many-arguments
-        args = {
-            'template': template,
-            'category': category if category is not None else self.category,
-        }
-        if paging == 'day':
-            args['date'] = self.date.format(utils.DAY_FORMAT)
-        elif paging == 'month':
-            args['date'] = self.date.format(utils.MONTH_FORMAT)
-        elif paging == 'year':
-            args['date'] = self.date.format(utils.YEAR_FORMAT)
-        elif paging == 'week':
-            args['date'] = self.date.span('week')[0].format(utils.WEEK_FORMAT)
-        elif paging == 'offset' or not paging:
-            args['id'] = self._record.id
-        else:
-            raise ValueError("Unknown paging type '{}'".format(paging))
-
-        if tag:
-            args['tag'] = tag
-
-        return flask.url_for('category', **args, _external=absolute)
 
     @cached_property
     def title(self):
@@ -194,11 +217,11 @@ class Entry(caching.Memoizable):
         markup -- If True, convert it from Markdown to HTML; otherwise, strip
             all markup (default: True)
         """
-        return CallableProxy(self._title)
+        def _title(markup=True, no_smartquotes=False, markdown_extensions=None):
+            return markdown.render_title(self._record.title, markup, no_smartquotes,
+                                         markdown_extensions)
+        return CallableProxy(_title)
 
-    def _title(self, markup=True, no_smartquotes=False, markdown_extensions=None):
-        return markdown.render_title(self._record.title, markup, no_smartquotes,
-                                     markdown_extensions)
 
     @cached_property
     def search_path(self):
@@ -333,31 +356,7 @@ class Entry(caching.Memoizable):
             'recurse': kwargs.get('recurse', category != self._record.category)
         }
 
-    def _previous(self, **kwargs):
-        """ Get the previous item in any particular category """
-        spec = self._pagination_default_spec(kwargs)
-        spec.update(kwargs)
 
-        query = queries.build_query(spec)
-        query = queries.where_before_entry(query, self._record)
-
-        for record in query.order_by(orm.desc(model.Entry.local_date),
-                                     orm.desc(model.Entry.id))[:1]:
-            return Entry(record)
-        return None
-
-    def _next(self, **kwargs):
-        """ Get the next item in any particular category """
-        spec = self._pagination_default_spec(kwargs)
-        spec.update(kwargs)
-
-        query = queries.build_query(spec)
-        query = queries.where_after_entry(query, self._record)
-
-        for record in query.order_by(model.Entry.local_date,
-                                     model.Entry.id)[:1]:
-            return Entry(record)
-        return None
 
     def get(self, name, default=None):
         """ Get a single header on an entry """

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -222,7 +222,6 @@ class Entry(caching.Memoizable):
                                          markdown_extensions)
         return CallableProxy(_title)
 
-
     @cached_property
     def search_path(self):
         """ The relative image search path for this entry """
@@ -312,8 +311,9 @@ class Entry(caching.Memoizable):
 
             body, more, is_markdown = self._entry_content
 
-            card = cards.extract_card(body or more, is_markdown, kwargs,
-                self.search_path)
+            card = cards.extract_card(body or more,
+                                      is_markdown, kwargs,
+                                      self.search_path)
 
             return flask.Markup((card.description or '').strip())
 
@@ -357,8 +357,6 @@ class Entry(caching.Memoizable):
             'category': category,
             'recurse': kwargs.get('recurse', category != self._record.category)
         }
-
-
 
     def get(self, name, default=None):
         """ Get a single header on an entry """
@@ -423,7 +421,6 @@ def get_entry_id(entry, fullpath, assign_id):
 
         limit = max(10, orm.get(orm.count(e) for e in model.Entry) * 5)
         attempt = 0
-
         while not entry_id or model.Entry.get(id=entry_id):
             # Stably generate a quasi-random entry ID from the file path
             md5 = hashlib.md5()

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -58,7 +58,7 @@ def map_template(category, template_list):
     for template in utils.as_list(template_list):
         path = os.path.normpath(category)
         while path is not None:
-            for extension in ['', '.html', '.htm', '.xml', '.json']:
+            for extension in ['', '.html', '.htm', '.xml', '.json', '.txt']:
                 candidate = os.path.join(path, template + extension)
                 file_path = os.path.join(config.template_folder, candidate)
                 if os.path.isfile(file_path):

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -297,10 +297,10 @@ class HTMLTransform(html.parser.HTMLParser):
         return ''.join(self._fed)
 
     def handle_entityref(self, name):
-        self.append('&' + name + ';')
+        self.handle_data('&' + name + ';')
 
     def handle_charref(self, name):
-        self.append('&#' + name + ';')
+        self.handle_data('&#' + name + ';')
 
     def error(self, message):
         """ Deprecated, per https://bugs.python.org/issue31844 """

--- a/tests/content/cards/html badly-formed.html
+++ b/tests/content/cards/html badly-formed.html
@@ -1,0 +1,10 @@
+Title: HTML with badly-formed paragraphs
+Date: 2019-06-28 15:12:41-07:00
+Entry-ID: 213
+UUID: bdbfa865-0689-5cc1-bfc7-ced877c5d431
+
+Let's write HTML like it's 1994.<p>
+
+Paragraphs are a marker, not a block element, right?<p>
+
+Just for fun here's a hanging paragraph.

--- a/tests/content/cards/html entry with summary.html
+++ b/tests/content/cards/html entry with summary.html
@@ -1,0 +1,7 @@
+Title: HTML entry with summary
+Summary: This is the summary.
+Date: 2019-06-28 15:11:29-07:00
+Entry-ID: 594
+UUID: 832e719e-1390-5885-9097-18d972cd7ff6
+
+This is not a summary.

--- a/tests/content/cards/html well-formed.html
+++ b/tests/content/cards/html well-formed.html
@@ -1,0 +1,8 @@
+Title: HTML entry with well-formed paragraphs
+Date: 2019-06-28 15:12:07-07:00
+Entry-ID: 545
+UUID: 19e362d7-e9e7-5eaa-ab6f-0e18c9ae67e3
+
+<p>This is a well-formed paragraph. <a href="/">Here is a link.</a></p>
+
+<p>This is also a well-formed paragraph.</p>

--- a/tests/content/cards/html with image.html
+++ b/tests/content/cards/html with image.html
@@ -1,0 +1,6 @@
+Title: HTML with image
+Date: 2019-06-28 15:49:59-07:00
+Entry-ID: 265
+UUID: 0b97346c-3a29-52dc-af40-a65dcc515145
+
+Hello! <img src="/images/rawr.jpg">

--- a/tests/content/cards/markdown entry with summary.md
+++ b/tests/content/cards/markdown entry with summary.md
@@ -1,0 +1,11 @@
+Title: Markdown entry, has a summary
+Date: 2019-06-28 15:10:08-07:00
+Entry-ID: 620
+UUID: 83960580-5ef1-587f-8900-29f3fdbeca27
+Summary: This is the summary.
+
+This is not the summary.
+
+.....
+
+This is the extended text.

--- a/tests/content/cards/markdown with image.md
+++ b/tests/content/cards/markdown with image.md
@@ -1,0 +1,6 @@
+Title: Markdown with image and first paragraph
+Date: 2019-06-28 15:49:43-07:00
+Entry-ID: 187
+UUID: 2c1b23c7-4674-5fac-90b2-9ce41facb2b1
+
+Hello! ![](/images/rawr.jpg)

--- a/tests/content/cards/markdown with paragraph.md
+++ b/tests/content/cards/markdown with paragraph.md
@@ -1,0 +1,12 @@
+Title: Markdown entry with initial paragraph
+Date: 2019-06-28 15:11:08-07:00
+Entry-ID: 165
+UUID: 8e6a7736-bd94-5a11-9f68-ab0ee65a78f7
+
+This is an initial paragraph. It should become part of the summary.
+
+This is the second paragraph. It should not.
+
+.....
+
+This is below-the-fold text.

--- a/tests/templates/cards/entry.txt
+++ b/tests/templates/cards/entry.txt
@@ -1,0 +1,15 @@
+==Card data==
+
+{{entry.card}}
+
+==Summary text==
+
+{{entry.summary}}
+
+==Body text==
+
+{{entry.body or '(no body)'}}
+
+==More text==
+
+{{entry.more or '(no more)'}}

--- a/tests/templates/style.css
+++ b/tests/templates/style.css
@@ -1,5 +1,4 @@
 @import url('{{static("pygments.default.css")}}');
-@import url('{{static("webmentions.css")}}');
 
 html {
     padding: 0;


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Fixes #219

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
This refactoring makes it a lot easier to follow the code flow for the various properties-that-are-also-functions in the various API classes, except for where the internal function is used from multiple call sites.

In doing this refactoring I also noticed some issues with entry.summary and entry.card; they would have both failed if parameters were passed to them on entries with a `Summary:` field, and HTML entries were being completely ignored. Now there is a very basic HTML card parser and cards/summaries go through the improved CallableProxy pattern.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
