### PR TITLE
Implement private content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ format:
 
 .PHONY: pylint
 pylint:
-	pipenv run pylint -f colorized publ
+	pipenv run pylint publ
 
 .PHONY: flake8
 flake8:

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -32,10 +32,10 @@
         },
         "authl": {
             "hashes": [
-                "sha256:6ffe48494a14e59131dc37e8322629bacf754ced7bcd1f49bf933b9f39a464aa",
-                "sha256:70c29c6178221a45aa0d7b78c7bf4ba3a279faf81b73b65844ec9df48aae2b26"
+                "sha256:7bf51842e2f4b6cf06f3336ed1cb5060d9faf847a9509cfaeab3110e1cd34789",
+                "sha256:d7d9693228faedfe39ad572d4bb4e4d7697422cfac4e7c3e806b8dee7a26e753"
             ],
-            "version": "==0.0.2"
+            "version": "==0.1.0"
         },
         "awesome-slugify": {
             "hashes": [

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -17,6 +17,7 @@ from . import maintenance, image
 
 LOGGER = logging.getLogger(__name__)
 
+
 class Publ(flask.Flask):
     """ A Publ application.
 
@@ -131,9 +132,6 @@ class Publ(flask.Flask):
                               login_path='/_login',
                               force_ssl=config.auth.get('AUTH_FORCE_SSL'))
 
-            @self.route('/_logout')
-            @self.route('/_logout/')
-            @self.route('/_logout/<path:redir>')
             def logout(redir=''):
                 """ Log out from the thing """
                 LOGGER.info("Logging out")
@@ -142,6 +140,13 @@ class Publ(flask.Flask):
 
                 flask.session['me'] = ''
                 return flask.redirect('/' + redir)
+
+            for route in [
+                    '/_logout',
+                    '/_logout/',
+                    '/_logout/<path:redir>'
+            ]:
+                self.add_url_rule(route, 'logout', logout)
 
         self._maint = maintenance.Maintenance()
 
@@ -227,8 +232,6 @@ class Publ(flask.Flask):
         if response.cache_control.max_age is None and 'CACHE_DEFAULT_TIMEOUT' in config.cache:
             response.cache_control.max_age = config.cache['CACHE_DEFAULT_TIMEOUT']
         return response
-
-
 
 
 def publ(name, cfg):

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -58,7 +58,9 @@ class Publ(flask.Flask):
         secret_key -- Authentication signing secret. This should remain private.
             The default value is randomly generated at every application restart.
         auth -- Authentication configuration. See the Authl configuration
-            documentation at [link TBD]
+            documentation at [link TBD]. Additionally, setting the key
+            AUTH_FORCE_SSL to a truthy value can be used to force the user to
+            switch to an SSL connection when they log in.
         """
 
         if Publ._instance and Publ._instance is not self:
@@ -120,7 +122,8 @@ class Publ(flask.Flask):
             caching.init_app(self, config.cache)
 
         if config.auth:
-            authl.setup_flask(self, config.auth)
+            authl.setup_flask(self, config.auth,
+                              force_ssl=config.auth.get('AUTH_FORCE_SSL'))
 
         self._maint = maintenance.Maintenance()
 

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -10,7 +10,7 @@ import logging
 import arrow
 import flask
 import werkzeug.exceptions
-import authl
+import authl.flask
 
 from . import config, rendering, model, index, caching, view, utils
 from . import maintenance, image
@@ -128,7 +128,7 @@ class Publ(flask.Flask):
             caching.init_app(self, config.cache)
 
         if config.auth:
-            authl.setup_flask(self, config.auth,
+            authl.flask.setup(self, config.auth,
                               login_path='/_login',
                               force_ssl=config.auth.get('AUTH_FORCE_SSL'))
 

--- a/publ/config.py
+++ b/publ/config.py
@@ -39,9 +39,10 @@ markdown_extensions = (
 )
 
 # Authentication
-secret_key = uuid.uuid4()
+secret_key = str(uuid.uuid4())
 auth = {}
 user_list = 'users.cfg'
+admin_user = 'admin'
 
 
 def setup(cfg):

--- a/publ/config.py
+++ b/publ/config.py
@@ -41,6 +41,7 @@ markdown_extensions = (
 # Authentication
 secret_key = uuid.uuid4()
 auth = {}
+user_list = 'users.cfg'
 
 
 def setup(cfg):

--- a/publ/config.py
+++ b/publ/config.py
@@ -42,7 +42,7 @@ markdown_extensions = (
 secret_key = str(uuid.uuid4())
 auth = {}
 user_list = 'users.cfg'
-admin_user = 'admin'
+admin_group = 'admin'
 
 
 def setup(cfg):

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -113,6 +113,14 @@ class Entry(caching.Memoizable):
         return CallableProxy(_permalink)
 
     @cached_property
+    def login(self):
+        """ Get a link specifically for logging in to the entry. """
+        def _loginlink(absolute=False, **kwargs):
+            pagelink = flask.url_for('entry', entry_id=self._record.id, **kwargs)
+            return flask.url_for('login', redir=pagelink[1:], _external=absolute)
+        return CallableProxy(_loginlink)
+
+    @cached_property
     def archive(self):
         """ Get a link to this entry in the context of a category template.
         Accepts the following arguments:

--- a/publ/model.py
+++ b/publ/model.py
@@ -87,7 +87,7 @@ class Entry(db.Entity):
         if not self.auth:
             return True
 
-        logger.debug("Computing auth for entry %d user %s", self.id, user)
+        logger.debug("Computing auth for entry %s user %s", self.file_path, user)
 
         if user and config.admin_user and config.admin_user in user.groups:
             logger.debug("User is admin")
@@ -160,6 +160,7 @@ class EntryAuth(db.Entity):
     allowed = orm.Required(bool)
 
     orm.composite_key(entry, order)
+
 
 def setup():
     """ Set up the database """

--- a/publ/model.py
+++ b/publ/model.py
@@ -166,8 +166,8 @@ class EntryAuth(db.Entity):
 class AuthLog(db.Entity):
     """ Authentication log for private entries """
     date = orm.Required(datetime.datetime, index=True)
-    entry = orm.Required(Entry, index=True)
-    user = orm.Optional(str, index=True)
+    entry = orm.Optional(Entry, index=True)
+    user = orm.Required(str, index=True)
     user_groups = orm.Required(str)
     authorized = orm.Required(bool)
 

--- a/publ/model.py
+++ b/publ/model.py
@@ -69,6 +69,7 @@ class Entry(db.Entity):
     tags = orm.Set("EntryTag")
 
     auth = orm.Set("EntryAuth")
+    auth_log = orm.Set("AuthLog")
 
     entry_template = orm.Optional(str)  # maps to Entry-Template
 
@@ -160,6 +161,15 @@ class EntryAuth(db.Entity):
     allowed = orm.Required(bool)
 
     orm.composite_key(entry, order)
+
+
+class AuthLog(db.Entity):
+    """ Authentication log for private entries """
+    date = orm.Required(datetime.datetime, index=True)
+    entry = orm.Required(Entry, index=True)
+    user = orm.Optional(str, index=True)
+    user_groups = orm.Required(str)
+    authorized = orm.Required(bool)
 
 
 def setup():

--- a/publ/model.py
+++ b/publ/model.py
@@ -89,7 +89,7 @@ class Entry(db.Entity):
 
         logger.debug("Computing auth for entry %s user %s", self.file_path, user)
 
-        if user and config.admin_user and config.admin_user in user.groups:
+        if user and user.is_admin:
             logger.debug("User is admin")
             return True
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -22,6 +22,7 @@ from . import view
 from . import caching
 from . import utils
 from . import queries
+from . import user
 from .caching import cache
 
 LOGGER = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -134,7 +135,7 @@ def render_publ_template(template, **kwargs):
         return text, caching.get_etag(text)
 
     try:
-        return do_render(template, request.args, **kwargs)
+        return do_render(template, request.args, user=user.get_active(), **kwargs)
     except queries.InvalidQueryError as err:
         raise http_error.BadRequest(err)
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -360,7 +360,8 @@ def render_entry(entry_id, slug_text='', category=''):
                       authorized=authorized)
 
         if not record.is_authorized(cur_user):
-            return redirect(url_for('login', redir=request.path[1:]))
+            page_link = url_for('entry', entry_id=entry_id, **request.args)
+            return redirect(url_for('login', redir=page_link[1:]))
 
     # check if the canonical URL matches
     if record.category != category or record.slug_text != slug_text:
@@ -373,7 +374,8 @@ def render_entry(entry_id, slug_text='', category=''):
         return redirect(url_for('entry',
                                 entry_id=entry_id,
                                 category=record.category,
-                                slug_text=record.slug_text if record.slug_text else None))
+                                slug_text=record.slug_text if record.slug_text else None,
+                                **request.args))
 
     # if the entry canonically redirects, do that now
     entry_redirect = record.redirect_url

--- a/publ/user.py
+++ b/publ/user.py
@@ -1,0 +1,58 @@
+""" Authenticated user functionality """
+
+import configparser
+import collections
+
+from werkzeug.utils import cached_property
+
+from . import caching
+from . import config
+
+
+@caching.cache.memoize()
+def get_groups():
+    """ Get the user->groups mappings """
+
+    # We only want empty keys; \000 is unlikely to turn up in a well-formed text file
+    cfg = configparser.ConfigParser(delimiters=('\000'), allow_no_value=True)
+    cfg.read(config.user_list)
+
+    groups = collections.defaultdict(set)
+
+    # populate the group list for each member
+    for group, members in cfg.items():
+        for member in members.keys():
+            groups[member].add(group)
+
+    return groups
+
+
+class User(caching.Memoizable):
+    """ An authenticated user """
+
+    def __init__(self, me):
+        self._me = me
+
+    def _key(self):
+        return User, self._me
+
+    @cached_property
+    def username(self):
+        """ The federated identity name of the user """
+        return self._me
+
+    @property
+    @caching.cache.memoize()
+    def groups(self):
+        """ The group memberships of the user """
+        groups = get_groups()
+        result = set()
+        pending = collections.deque([self._me])
+
+        while pending:
+            check = pending.popleft()
+            if check not in result:
+                result.add(check)
+                pending += groups.get(check, [])
+
+        return result

--- a/publ/user.py
+++ b/publ/user.py
@@ -63,6 +63,7 @@ class User(caching.Memoizable):
 
     @property
     def is_admin(self):
+        """ Returns whether this user has administrator permissions """
         return config.admin_user and config.admin_user in self.groups
 
 

--- a/publ/user.py
+++ b/publ/user.py
@@ -64,7 +64,7 @@ class User(caching.Memoizable):
     @property
     def is_admin(self):
         """ Returns whether this user has administrator permissions """
-        return config.admin_user and config.admin_user in self.groups
+        return config.admin_group and config.admin_group in self.groups
 
 
 def get_active():

--- a/publ/user.py
+++ b/publ/user.py
@@ -61,6 +61,10 @@ class User(caching.Memoizable):
 
         return result
 
+    @property
+    def is_admin(self):
+        return config.admin_user and config.admin_user in self.groups
+
 
 def get_active():
     """ Get the active user and add it to the request stash """

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -11,6 +11,7 @@ import arrow
 import flask
 import slugify
 from werkzeug.utils import cached_property
+import werkzeug.routing
 
 from . import config, model
 
@@ -341,3 +342,17 @@ def as_list(item):
         return item
 
     return [item]
+
+class CategoryConverter(werkzeug.routing.PathConverter):
+    """ A version of PathConverter that doesn't accept paths beginning with _ """
+    def to_python(self, value):
+        if value[0] == '_':
+            raise werkzeug.routing.ValidationError
+        return super().to_python(value)
+
+class TemplateConverter(werkzeug.routing.UnicodeConverter):
+    """ A version of UnicodeConverter that doesn't accept strings beginning with _ """
+    def to_python(self, value):
+        if value[0] == '_':
+            raise werkzeug.routing.ValidationError
+        return super().to_python(value)

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -343,15 +343,19 @@ def as_list(item):
 
     return [item]
 
+
 class CategoryConverter(werkzeug.routing.PathConverter):
     """ A version of PathConverter that doesn't accept paths beginning with _ """
+
     def to_python(self, value):
         if value[0] == '_':
             raise werkzeug.routing.ValidationError
         return super().to_python(value)
 
+
 class TemplateConverter(werkzeug.routing.UnicodeConverter):
     """ A version of UnicodeConverter that doesn't accept strings beginning with _ """
+
     def to_python(self, value):
         if value[0] == '_':
             raise werkzeug.routing.ValidationError

--- a/publ/view.py
+++ b/publ/view.py
@@ -11,7 +11,7 @@ from pony import orm
 from . import model, utils, queries, caching, user
 from .entry import Entry
 
-LOGGER=logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 # Prioritization list for pagination
 OFFSET_PRIORITY = ['date', 'start', 'last', 'first']

--- a/publ/view.py
+++ b/publ/view.py
@@ -126,6 +126,12 @@ class View(caching.Memoizable):
         """ Gets entries which are authorized for the current viewer """
         cur_user = user.get_active()
         LOGGER.debug("Getting authorized entries for view %s user %s", self, cur_user)
+        # Known limitation to this approach: filtered entries reduce the number of
+        # entries per page, which both leaks information and makes the possibility
+        # of empty pages if there's enough private content. At present this seems
+        # like a minor concern compared to the difficulty of extending pages based
+        # on content filtering, however. In the future it would be helpful to figure
+        # out a databvase-side query that will work for the content filtering.
         return [Entry(e) for e in self._entries
                 if e.is_authorized(cur_user)]
 

--- a/tests.py
+++ b/tests.py
@@ -26,6 +26,7 @@ config = {
     } if os.environ.get('TEST_CACHING') else {
         'CACHE_NO_NULL_WARNING': True
     },
+    'user_list': 'tests/users.cfg'
 }
 
 app = publ.Publ(__name__, config)

--- a/tests.py
+++ b/tests.py
@@ -12,6 +12,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 config = {
     # Leave this off to do an in-memory database
+    'secret_key': 'this test suite is insecure as heck',
     'database_config': {
         'provider': 'sqlite',
         'filename': os.path.join(APP_PATH, 'index.db')
@@ -27,7 +28,8 @@ config = {
         'CACHE_NO_NULL_WARNING': True
     },
     'auth': {
-        'TEST_ENABLED': True
+        'TEST_ENABLED': True,
+        'INDIELOGIN_CLIENT_ID': 'http://localhost'
     },
     'user_list': 'tests/users.cfg'
 }

--- a/tests.py
+++ b/tests.py
@@ -26,6 +26,9 @@ config = {
     } if os.environ.get('TEST_CACHING') else {
         'CACHE_NO_NULL_WARNING': True
     },
+    'auth': {
+        'TEST_ENABLED': True
+    },
     'user_list': 'tests/users.cfg'
 }
 

--- a/tests/content/auth/admins.md
+++ b/tests/content/auth/admins.md
@@ -1,0 +1,9 @@
+Title: admin only
+Auth: admin
+Date: 2019-07-06 02:29:32-07:00
+Entry-ID: 562
+UUID: a104308a-3235-5a23-a81e-a0251d479913
+
+This entry is only visible to admins.
+
+Also all entries are always visible to admins.

--- a/tests/content/auth/allow everyone.md
+++ b/tests/content/auth/allow everyone.md
@@ -1,0 +1,7 @@
+Title: Entry that allows everyone
+Auth: *
+Date: 2019-07-05 16:30:07-07:00
+Entry-ID: 387
+UUID: 7700c402-26f6-529a-a581-7a170961a14f
+
+This entry should be visible to anyone who's logged in.

--- a/tests/content/auth/allow everyone.md
+++ b/tests/content/auth/allow everyone.md
@@ -1,4 +1,4 @@
-Title: Entry that allows everyone
+Title: Entry that just requires login
 Auth: *
 Date: 2019-07-05 16:30:07-07:00
 Entry-ID: 387

--- a/tests/content/auth/allow logged-out.md
+++ b/tests/content/auth/allow logged-out.md
@@ -1,0 +1,7 @@
+Title: Entry that only appears for logged-out users
+Auth: !*
+Date: 2019-07-05 16:30:55-07:00
+Entry-ID: 682
+UUID: 1e4d7d1d-2f89-581c-854b-b763ae8501b6
+
+This should only appear if you're not logged in.

--- a/tests/content/auth/friends and specific.md
+++ b/tests/content/auth/friends and specific.md
@@ -1,0 +1,7 @@
+Title: Friends + specific user
+Auth: friends test:specific
+Date: 2019-07-05 23:37:20-07:00
+Entry-ID: 107
+UUID: e63eff37-042b-58bf-8330-ace5a5db6ab7
+
+This should appear to `test:friend1`, `test:good_friend1`, and `test:specific`

--- a/tests/content/auth/friends but not good_friends.md
+++ b/tests/content/auth/friends but not good_friends.md
@@ -1,0 +1,8 @@
+Title: Group 'friends' but not 'good_friends'
+Auth: friends !good_friends
+Date: 2019-07-05 23:37:20-07:00
+Entry-ID: 716
+UUID: 48d39c3a-2e5c-5af0-aafb-8f31dd023db0
+
+Should appear for `test:friend1` but not `test:good_friend1` or `test:good_friend2`
+

--- a/tests/content/auth/friends except friend2.md
+++ b/tests/content/auth/friends except friend2.md
@@ -1,0 +1,7 @@
+Title: Friends except for friend2
+Auth: friends !test:friend2
+Date: 2019-07-05 23:37:20-07:00
+Entry-ID: 181
+UUID: 15f81423-eadf-53f0-b7e8-b2998dbbe540
+
+Should appear to `test:friend1` and `test:friend3`, but not `test:friend2`

--- a/tests/content/auth/friends.md
+++ b/tests/content/auth/friends.md
@@ -1,0 +1,7 @@
+Title: Group 'friends'
+Auth: friends
+Date: 2019-07-05 16:31:32-07:00
+Entry-ID: 749
+UUID: 279c0fb0-b351-5322-84b9-14ea9ac36d8d
+
+Should appear to `test:friend` and also `test:good_friend`

--- a/tests/content/auth/no_auth.md
+++ b/tests/content/auth/no_auth.md
@@ -1,0 +1,6 @@
+Title: Entry with no auth
+Date: 2019-07-05 16:29:47-07:00
+Entry-ID: 326
+UUID: f5315545-3a62-5e90-8e65-59c8471189c2
+
+This entry has no authorization.

--- a/tests/templates/_entry.html
+++ b/tests/templates/_entry.html
@@ -39,6 +39,14 @@
 
     <div id="content">
         <div class="entries">
+            {% if entry.is_unauthorized %}
+                {% if user %}
+                <p>You are logged in as `{{user.name}}`, and do not currently have access to this entry. If you have another account you can try <a href="{{entry.login}}">logging in as someone else</a>, or you can try contacting
+                the administrator of this site for access.</p>
+                {% else %}
+                <p>This entry is protected. Please <a href="{{entry.login}}">log in</a> to gain access.</p>
+                {% endif %}
+            {% else %}
             <article class="h-entry">
             {% block entry %}
             <div class="posted">Last updated: <time class="dt-posted" datetime="{{entry.date.isoformat()}}">{{entry.last_modified.format('YYYY-MM-DD h:mm A')}} ({{entry.last_modified.humanize()}})</time>
@@ -58,6 +66,7 @@
             </div>
             {% endblock %}
             </article>
+            {% endif %}
 
             <section id="webmentions"></section>
         </div>

--- a/tests/templates/auth/index.html
+++ b/tests/templates/auth/index.html
@@ -6,10 +6,11 @@
 <h2>Auth testing</h2>
 
 {% if user %}
-<h3>Current user: {{user.name}} (<a href="{{url_for('logout',redir=request.path[1:])}}">logout</a>)</h3>
+<h3>Current user: <code>{{user.name}}</code> (<a href="{{url_for('logout',redir=request.path[1:])}}">logout</a>)</h3>
+<p>Memberships:</p>
 <ul>
     {% for group in user.groups %}
-    <li>Group: {{group}}</li>
+    <li>{{group}}</li>
     {% endfor %}
 </ul>
 {% endif %}

--- a/tests/templates/auth/index.html
+++ b/tests/templates/auth/index.html
@@ -1,0 +1,24 @@
+{% extends '/index.html' %}
+
+{% block navigation %}
+{{super()}}
+
+<h2>Auth testing</h2>
+
+{% if user %}
+<h3>Current user: {{user.name}} (<a href="{{url_for('logout',redir=request.path[1:])}}">logout</a>)</h3>
+<ul>
+    {% for group in user.groups %}
+    <li>Group: {{group}}</li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+<h3>Test users</h3>
+<ul>
+    {% for name in ('admin','good_friend1','good_friend2','friend1','friend2','friend3','friend3_other1','friend3_other2','mutual1','mutual2','specific') %}
+    <li><a href="{{url_for('login',me='test:'+name,redir=request.path[1:])}}">{{name}}</a></li>
+    {% endfor %}
+</ul>
+
+{% endblock %}

--- a/tests/templates/feed.xml
+++ b/tests/templates/feed.xml
@@ -66,7 +66,7 @@
         <id>urn:uuid:{{entry.uuid}}</id>
         <author><name>{{ entry.author if entry.author else "fluffy" }}</name></author>
         <content type="html">
-            This is a private entry. Please <a href="entry.link">log in</a> to view it.
+            This is a private entry. Please <a href="{{entry.login(absolute=True)}}">log in</a> to view it.
         </content>
     </entry>
     {% endfor %}

--- a/tests/templates/feed.xml
+++ b/tests/templates/feed.xml
@@ -55,4 +55,19 @@
         <link>{{entry.permalink(absolute=True)}}</link>
     </at:deleted-entry>
     {% endfor %}
+
+    {% for entry in view.unauthorized %}
+    <entry>
+        <title>{{entry.title(markup=False,no_smartquotes=True,always_show=True)}} [private]</title>
+        <link href="{{ entry.permalink(absolute=True) }}" rel="alternate" type="text/html" />
+        <link href="{{ entry.login(absolute=True) }}" rel="login" type="text/html" />
+        <published>{{entry.date.isoformat()}}</published>
+        <updated>{{entry.last_modified.isoformat()}}</updated>
+        <id>urn:uuid:{{entry.uuid}}</id>
+        <author><name>{{ entry.author if entry.author else "fluffy" }}</name></author>
+        <content type="html">
+            This is a private entry. Please <a href="entry.link">log in</a> to view it.
+        </content>
+    </entry>
+    {% endfor %}
 </feed>

--- a/tests/templates/index.html
+++ b/tests/templates/index.html
@@ -58,6 +58,12 @@
 
     <div class="entries">
 
+        {% if not user and content.unauthorized %}
+        <div class="login">
+            <p>You are missing one or more friends-only entries. Please <a href="{{url_for('login',redir=request.path[1:])}}">log in</a>.</p>
+        </div>
+        {% endif %}
+
         {% for entry in content.entries %}
 
         <article class="h-entry entry">

--- a/tests/users.cfg
+++ b/tests/users.cfg
@@ -1,0 +1,30 @@
+# admin group should only contain the admin
+[admin]
+test:admin
+
+# good_friends should contain admin and the two good_friends
+[good_friends]
+admin
+test:good_friend1
+test:good_friend2
+
+# friends group should contain good_friends (and therefore admin)
+[friends]
+good_friends
+test:friend1
+test:friend2
+test:friend3
+
+# this friend has multiple identities
+[test:friend3]
+test:friend3_other1
+test:friend3_other2
+
+# mutually-recursive sections should be fine
+[mutual1]
+test:mutual1
+mutual2
+
+[mutual2]
+test:mutual2
+mutual1

--- a/tests/users.cfg
+++ b/tests/users.cfg
@@ -1,6 +1,8 @@
 # admin group should only contain the admin
 [admin]
 test:admin
+test:also_an_admin
+http://beesbuzz.biz/
 
 # good_friends should contain admin and the two good_friends
 [good_friends]


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Closes #147 - allows for a basic Authl configuration and uses it to allow fine-grained private access to entries.

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Entries for which the user isn't authorized won't appear in views, except with minimal data in the `view.unauthorized` list. Direct access to an entry redirects to the login page (currently just the minimal Authl stub page; see issue #233 for an improved login flow).

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Created new test suite in `/auth/`

## Got a site to show off?

<!-- If so, link to it here! -->
