### PR TITLE
Improve the unauthorized flow for logged-in users

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -207,7 +207,7 @@ def render_category(category='', template=None):
     # Forbidden template types
     if template and template.startswith('_'):
         raise http_error.Forbidden("Template is private")
-    if template in ['entry', 'error', 'login']:
+    if template in ['entry', 'error', 'login', 'unauthorized']:
         raise http_error.BadRequest("Invalid view requested")
 
     if category:
@@ -305,6 +305,13 @@ def render_entry(entry_id, slug_text='', category=''):
         user.log_access(record, cur_user, authorized)
 
         if not record.is_authorized(cur_user):
+            if cur_user:
+                tmpl = map_template(category, 'unauthorized')
+                if not tmpl:
+                    raise http_error.Forbidden("User {name} does not have access".format(name=cur_user.name))
+                return render_publ_template(tmpl,
+                    Entry(record),
+                    category=Category(category))[0], 403
             login_url = url_for('entry', entry_id=entry_id, **request.args)
             return redirect(url_for('login', redir=login_url[1:]))
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -310,7 +310,7 @@ def render_entry(entry_id, slug_text='', category=''):
                 if not tmpl:
                     raise http_error.Forbidden("User {name} does not have access".format(name=cur_user.name))
                 return render_publ_template(tmpl,
-                    Entry(record),
+                    entry=Entry(record),
                     category=Category(category))[0], 403
             login_url = url_for('entry', entry_id=entry_id, **request.args)
             return redirect(url_for('login', redir=login_url[1:]))

--- a/tests/templates/auth/unauthorized.html
+++ b/tests/templates/auth/unauthorized.html
@@ -1,0 +1,3 @@
+<p>Sorry, user {{user.name}} can't access entry {{entry.id}}. Better luck next time.</p>
+
+<p>You could try <a href="{{url_for('login',redir=request.full_path[1:])}}">logging in as someone else</a> or <a href="{{url_for('logout',redir=request.full_path[1:])}}">logging out</a> and see if that helps.</p>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
If a user is logged in and doesn't have access, provide a better signaling mechanism. Fixes #247 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
If a user is logged in and doesn't have access to an entry, Publ will render a 403 page using the `unauthorized` template (falling back to the usual 403 handler) so that they get an appropriate message regarding why they can't access the page.

