### PR TITLE
Add login and logout helpers

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -120,7 +120,9 @@ class Publ(flask.Flask):
             get_view=view.get_view,
             arrow=arrow,
             static=utils.static_url,
-            get_template=rendering.get_template
+            get_template=rendering.get_template,
+            login=utils.auth_link('login'),
+            logout=utils.auth_link('logout')
         )
 
         caching.init_app(self, config.cache)

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -360,3 +360,23 @@ class TemplateConverter(werkzeug.routing.UnicodeConverter):
         if value[0] == '_':
             raise werkzeug.routing.ValidationError
         return super().to_python(value)
+
+def auth_link(endpoint):
+    """ Generates a function that maps an optional redir parameter to the specified
+    auth endpoint. """
+    def endpoint_link(redir=None, **kwargs):
+        if redir is None:
+            # nothing specified so use the current request path
+            redir = flask.request.full_path
+        else:
+            # resolve CallableProxy if present
+            redir = str(redir)
+
+        # strip off leading slashes
+        redir = re.sub(r'^/*', r'', redir)
+        # if there's a trailing ? strip that off too
+        redir = re.sub(r'\?$', r'', redir)
+
+        return flask.url_for(endpoint, redir=redir, **kwargs)
+
+    return CallableProxy(endpoint_link)

--- a/tests/templates/auth/index.html
+++ b/tests/templates/auth/index.html
@@ -8,7 +8,9 @@
 {% if user %}
 <h3>Current user:</h3>
 <ul>
-<li>Signed in as <code>{{user.name}}</code>  (<a href="{{url_for('logout',redir=request.full_path[1:])}}">logout</a>)</li>
+<li>Signed in as <code>{{user.name}}</code></li>
+<li><a href="{{logout}}">logout</a></li>
+<li><a href="{{login}}">change user</a></li>
 <li>Group memberships:
 <ul>
     {% for group in user.groups %}
@@ -22,7 +24,7 @@
 <h3>Test users</h3>
 <ul>
     {% for name in ('admin','good_friend1','good_friend2','friend1','friend2','friend3','friend3_other1','friend3_other2','mutual1','mutual2','specific') %}
-    <li><a href="{{url_for('login',me='test:'+name,redir=request.full_path[1:])}}">{{name}}</a></li>
+    <li><a href="{{login(me='test:'+name)}}">{{name}}</a></li>
     {% endfor %}
 </ul>
 

--- a/tests/templates/auth/unauthorized.html
+++ b/tests/templates/auth/unauthorized.html
@@ -1,3 +1,6 @@
 <p>Sorry, user {{user.name}} can't access entry {{entry.id}}. Better luck next time.</p>
 
-<p>You could try <a href="{{url_for('login',redir=request.full_path[1:])}}">logging in as someone else</a> or <a href="{{url_for('logout',redir=request.full_path[1:])}}">logging out</a> and see if that helps.</p>
+<p>You could try <a href="{{login}}">logging in as someone else</a> or <a href="{{logout}}">logging out</a> and see if that helps.</p>
+
+<p>Or you can <a href="{{logout(redir=category.link)}}">logout and go directly to the category</a>.</p>
+


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Add `login` and `logout` template objects. Fixes #246 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Templates now get `login` and `logout` which provide an easy way to produce correct auth-related links. They can be called with or without parameters; if given a parameter it will be used as the redirection path, and additional parameters can be sent to the handler itself, e.g. `me` for specifying a username to log in as.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Updated the various auth-related templates and hammered away at this for a bit.

## Got a site to show off?

<!-- If so, link to it here! -->
