### PR TITLE
Remove spurious image set attributes

### DIFF
--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -84,8 +84,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
                      container_args.get('div_style')):
             text = '{tag}{text}</div>'.format(
                 tag=utils.make_tag('div',
-                                   {'class': container_args.get('div_class'),
-                                    'style': container_args.get('div_style')}),
+                                   {'class': container_args.get('div_class') or False,
+                                    'style': container_args.get('div_style') or False}),
                 text=text)
 
         # if text is ''/falsy then misaka interprets this as a failed parse...


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Fixes #226 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
Turns out feedvalidator barfs on malformed `style` attributes.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Looked at image rendition tests; before there were a lot of `<div class="foo" style>`, after it's just `<div class="foo">`.
