### PR TITLE
Refactor cache key generation

### DIFF
--- a/publ/caching.py
+++ b/publ/caching.py
@@ -49,14 +49,18 @@ def get_etag(text):
 
 
 class Memoizable(ABC):
-    """ Add this interface to a method to make it stably memoizable with the declared _key """
+    """ Add this interface to a class to make it stably memoizable. """
 
     @abstractmethod
     def _key(self):
-        pass
+        """
+            This should return a value that will be unique across all
+            objects of this class.
+        """
 
     def __repr__(self):
-        return repr(self._key())
+        return "{c}({k})".format(c=self.__class__.__name__,
+                                 k=self._key()).replace(' ', '_')
 
     def __hash__(self):
         return hash(self._key())

--- a/publ/category.py
+++ b/publ/category.py
@@ -61,7 +61,7 @@ class Category(caching.Memoizable):
         self._record = model.Category.get(category=path)
 
     def _key(self):
-        return Category, self.path
+        return self.path
 
     @cached_property
     def link(self):

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -46,7 +46,7 @@ class Entry(caching.Memoizable):
         self._record = record   # index record
 
     def _key(self):
-        return Entry, self._record.id, self._record.file_path
+        return self._record.id, self._record.file_path
 
     @cached_property
     def date(self):

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -36,7 +36,7 @@ class CallableProxy:
 
     def __call__(self, *args, **kwargs):
         # use the new kwargs to override the defaults
-        kwargs = dict(self._default_kwargs, **kwargs)
+        kwargs = {**self._default_kwargs, **kwargs}
 
         # override args as well
         pos_args = [*args, *self._default_args[len(args):]]

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -6,6 +6,7 @@ import html.parser
 import os
 import re
 import urllib.parse
+import logging
 
 import arrow
 import flask
@@ -15,6 +16,7 @@ from werkzeug.utils import cached_property
 
 from . import config, model
 
+LOGGER=logging.getLogger(__name__)
 
 class CallableProxy:
     """ Wrapper class to make args possible on properties """
@@ -366,12 +368,14 @@ def auth_link(endpoint):
     """ Generates a function that maps an optional redir parameter to the specified
     auth endpoint. """
     def endpoint_link(redir=None, **kwargs):
+        LOGGER.debug("Getting %s for redir=%s kwargs=%s", endpoint, redir, kwargs)
         if redir is None:
             # nothing specified so use the current request path
             redir = flask.request.full_path
         else:
             # resolve CallableProxy if present
             redir = str(redir)
+        LOGGER.debug("  Resulting redir = %s", redir)
 
         # strip off leading slashes
         redir = re.sub(r'^/*', r'', redir)

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -34,17 +34,6 @@ class CallableProxy:
         self._default_args = args
         self._default_kwargs = kwargs
 
-    @cached_property
-    def _default(self):
-        """ Get the default function return """
-
-        if self._default_args:
-            return self._func(
-                *self._default_args,
-                **self._default_kwargs)
-
-        return self._func(**self._default_kwargs)
-
     def __call__(self, *args, **kwargs):
         # use the new kwargs to override the defaults
         kwargs = dict(self._default_kwargs, **kwargs)
@@ -55,19 +44,19 @@ class CallableProxy:
         return self._func(*pos_args, **kwargs)
 
     def __getattr__(self, name):
-        return getattr(self._default, name)
+        return getattr(self(), name)
 
     def __bool__(self):
-        return bool(self._default)
+        return bool(self())
 
     def __len__(self):
-        return 1 if self._default else 0
+        return 1 if self() else 0
 
     def __str__(self):
-        return str(self._default)
+        return str(self())
 
     def __iter__(self):
-        return self._default.__iter__()
+        return self().__iter__()
 
 
 class TrueCallableProxy(CallableProxy):

--- a/publ/view.py
+++ b/publ/view.py
@@ -101,7 +101,7 @@ class View(caching.Memoizable):
             self.type = None
 
     def _key(self):
-        return View, repr(self.spec)
+        return repr(self.spec)
 
     def __str__(self):
         return str(self.link())

--- a/tests/content/auth/friends and specific.md
+++ b/tests/content/auth/friends and specific.md
@@ -4,4 +4,4 @@ Date: 2019-07-05 23:37:20-07:00
 Entry-ID: 107
 UUID: e63eff37-042b-58bf-8330-ace5a5db6ab7
 
-This should appear to `test:friend1`, `test:good_friend1`, and `test:specific`
+This should appear to everyone in the `friend` group and to `test:specific`


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Fixes #255 and also cleans up the way cache keys are generated in general

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
The main problem behind issue 255 was that the `@caching.memoize` decorator appears to NOT md5sum the function name as part of the cache key, which was causing the `user.groups` property (and *only* that) to fail memoization on memcached. The direct fix for that was to refactor the way that `User.groups` was put together, by putting that functionality into `user.get_groups`, which also no longer returns the total group->user mapping (which wasn't very useful anyway).

As part of my investigations into this I realized that there's an easier/cleaner way to generate cache keys anyway.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Configured tests.py to use the memcached backend and ensured that the error spew went away, indicating that the data is actually being cached. Also ensured that the auth tests still worked as intended.

Also found and fixed an issue with how `CallableProxy` caches the default return value, even if things aren't idempotent; this was affecting the correctness of the `login` and `logout` template functions.

## Got a site to show off?

<!-- If so, link to it here! -->
