### PR TITLE
Prune the auth log

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -180,6 +180,11 @@ class Publ(flask.Flask):
                                                    config.image_cache_age),
                                  config.image_cache_interval)
 
+        if config.auth_log_prune_interval and config.auth_log_prune_age:
+            self._maint.register(functools.partial(user.prune_log,
+                                                   config.auth_log_prune_age),
+                                 config.auth_log_prune_interval)
+
         self.before_request(self._maint.run)
 
         if 'CACHE_THRESHOLD' in config.cache:

--- a/publ/config.py
+++ b/publ/config.py
@@ -44,6 +44,8 @@ secret_key = str(uuid.uuid4())
 auth = {}
 user_list = 'users.cfg'
 admin_group = 'admin'
+auth_log_prune_interval = 3600
+auth_log_prune_age = 86400 * 30  # one month
 
 
 def setup(cfg):

--- a/tests.py
+++ b/tests.py
@@ -32,7 +32,7 @@ config = {
         'INDIELOGIN_CLIENT_ID': 'http://localhost',
         'MASTODON_NAME': 'Publ test suite',
     },
-    'user_list': 'tests/users.cfg'
+    'user_list': 'tests/users.cfg',
 }
 
 app = publ.Publ(__name__, config)


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Prune auth log entries periodically. Fixes #259 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Adds a periodic maintenance task which will purge auth log entries. Default is to keep the last month of auth log entries, checked once an hour.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Set purge interval to 30 seconds and max age to 90 seconds, observed that things worked correctly

## Got a site to show off?

<!-- If so, link to it here! -->
