### PR TITLE
If the user is already logged in, redirect

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -250,8 +250,15 @@ def render_category(category='', template=None):
                       'ETag': etag}
 
 
-def render_login_form(**kwargs):
+def render_login_form(redir=None, **kwargs):
     """ Renders the login form using the mapped login template """
+
+    # If the user is already logged in, just redirect them to where they're
+    # going; if they weren't authorized then they'll just get the unauthorized
+    # view.
+    if redir is not None and flask.session.get('me'):
+        return flask.redirect(redir)
+
     tmpl = map_template('', 'login')
     if not tmpl:
         # fall back to the default Authl handler


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Fixes #275 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
If the user is already logged in, send them along to the page. If they aren't authorized, the unauthorized handler will take care of them.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Logged in as `test:admin`, opened several `/auth/` pages in tabs, including the admin dashboard and some admin-only entries. Logged out, reloaded pages, logged in as `test:moo`, reloaded pages, etc.

## Got a site to show off?

<!-- If so, link to it here! -->
