### PR TITLE
Improve URL routing and canonicization

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,2 +1,5 @@
+[MESSAGES CONTROL]
+disable=import-outside-toplevel
+
 [SIMILARITIES]
 ignore-imports=yes

--- a/runTests.sh
+++ b/runTests.sh
@@ -4,4 +4,4 @@ if [ "$1" != "fast" ] ; then
     pipenv install --dev || exit 1
 fi
 
-FLASK_DEBUG=1 FLASK_ENV=development pipenv run python tests.py
+FLASK_DEBUG=1 FLASK_ENV=development FLASK_APP=tests.py pipenv run flask run

--- a/tests/content/err/_.cat
+++ b/tests/content/err/_.cat
@@ -1,0 +1,1 @@
+Name: Error handling

--- a/tests/content/err/failure.md
+++ b/tests/content/err/failure.md
@@ -2,5 +2,8 @@ Title: failure
 Date: 2019-05-13 20:57:39-07:00
 Entry-ID: 724
 UUID: f003e67a-c3e8-5f91-8ae1-f4def03843f1
+Status: DRAFT
 
 This category's index should not work. In prod it should show a pretty error page, in debug it should show the exception handler.
+
+The entry itself should generate a 403.

--- a/tests/content/redirections/redirect filename.md
+++ b/tests/content/redirections/redirect filename.md
@@ -4,4 +4,4 @@ Date: 2019-02-20 20:57:56-08:00
 Entry-ID: 1203
 UUID: b3bf620e-9e50-5ace-aec3-376745c0191c
 
-Should redirect to [the image attribute test](../image attributes.md)
+Should redirect to [the image attribute test](../images/image attributes.md)

--- a/tests/content/redirections/redirect image.md
+++ b/tests/content/redirections/redirect image.md
@@ -4,4 +4,4 @@ Date: 2019-02-20 20:55:56-08:00
 Entry-ID: 79
 UUID: b2780cd1-2ae6-5da6-a946-fb121820dd72
 
-This should send us to a 320-pixel-wide rawr, same as [this one](/rawr.jpg{320})
+This should send us to a 320-pixel-wide rawr, same as [this one](/images/rawr.jpg{320})

--- a/tests/templates/auth/unauthorized.html
+++ b/tests/templates/auth/unauthorized.html
@@ -11,7 +11,7 @@
     <div id="login">
         <h1>Authorization Pending</h1>
         <div id="notify">
-        <p>Sorry, <code>{{user.name}}</code>, you don't currently have access to this page. You can try <a href="{{login}}">logging in as someone else</a> or <a href="{{logout(category.link if category else None)}}">logging out entirely</a>.</p>
+        <p>Sorry, <code>{{user.name}}</code>, you don't currently have access to this page. You can try <a href="{{logout}}">logging in as someone else</a> or <a href="{{logout(category.link if category else None)}}">logging out entirely</a>.</p>
     </div>
         <div id="powered">
             <p>Powered by <a href="https://github.com/PlaidWeb/Authl">Authl</a></p>

--- a/tests/templates/tags/index.html
+++ b/tests/templates/tags/index.html
@@ -1,5 +1,7 @@
 <h1>Tagging test</h1>
 
+<p>request.full_path: <code>{{request.full_path}}</code></p>
+
 <p>Spec: <code>{{view.spec}}</code></p>
 
 <p><a href="{{view(tag=None).link}}">clear all tags</a> <a href="browse">tag browser</a></p>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Simplify some of the routing rules and the way that entry URLs get canonicized

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Instead of comparing the slug_text and category, just compare the URL with the expected URL. This will help with #286 down the road but it mostly just cleans up some code now. It also finally removes the ambiguity around empty slugs, as to whether the URL should end with a `-` or not.

Also fixed a bunch of tests which have been broken for a while.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Did the usual litany of redirection tests, on both authorized and unauthorized entries, including test entry 557 (empty slug).

## Got a site to show off?

<!-- If so, link to it here! -->
