### PR TITLE
Treat not-logged-in as a 401 error instead of redirecting

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -39,10 +39,10 @@
         },
         "authl": {
             "hashes": [
-                "sha256:0cbabc9f6c7e5712cf34765d17ba9841d4ce1e5127ad2f3bae3f67c9b4063072",
-                "sha256:3a857452240aa24db8c1fce54f005e9aa71fcfc134ed07efae0b6c379985e160"
+                "sha256:4a26a35a30a799336a58e8feaea8595dde1206951e3ef1f33cb41fb96e42f240",
+                "sha256:ca1d15e53f95bb8527cebf96bb72f0fb183b262a0888567f5bd99b7c1201771c"
             ],
-            "version": "==0.2.2"
+            "version": "==0.2.3"
         },
         "awesome-slugify": {
             "hashes": [
@@ -88,10 +88,12 @@
                 "sha256:7cfcfda59ef1f95b9f729c56fe8a4041899f96b72685d36ef16a3440a0f85da8",
                 "sha256:819f8d5197c2684524637f940445c06e003c4a541f9983fd30d6deaa2a5487d8",
                 "sha256:825ecffd9574557590e3225560a8a9d751f6ffe4a49e3c40918c9969b93395fa",
+                "sha256:8a2bcae2258d00fcfc96a9bde4a6177bc4274fe033f79311c5dd3d3148c26518",
                 "sha256:9009e917d8f5ef780c2626e29b6bc126f4cb2a4d43ca67aa2b40f2a5d6385e78",
                 "sha256:9c77564a51d4d914ed5af096cd9843d90c45b784b511723bd46a8a9d09cf16fc",
                 "sha256:a19089fa74ed19c4fe96502a291cfdb89223a9705b1d73b3005df4256976142e",
                 "sha256:a40ed527bffa2b7ebe07acc5a3f782da072e262ca994b4f2085100b5a444bbb2",
+                "sha256:b8f09f21544b9899defb09afbdaeb200e6a87a2b8e604892940044cf94444644",
                 "sha256:bb75ba21d5716abc41af16eac1145ab2e471deedde1f22c6f99bd9f995504df0",
                 "sha256:e22a00c0c81ffcecaf07c2bfb3672fa372c50e2bd1024ffee0da191c1b27fc71",
                 "sha256:e55b5a746fb77f10c83e8af081979351722f6ea48facea79d470b3731c7b2891",
@@ -290,6 +292,12 @@
             ],
             "version": "==5.1.2"
         },
+        "read-only-property": {
+            "hashes": [
+                "sha256:347f28042fe95cd78ab57ab5d6ab50fc74e9757b1530e8b129b046990250183d"
+            ],
+            "version": "==0.1"
+        },
         "regex": {
             "hashes": [
                 "sha256:1e9f9bc44ca195baf0040b1938e6801d2f3409661c15fe57f8164c678cfc663f",
@@ -423,11 +431,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
-                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
+                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
+                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
             ],
             "index": "pypi",
-            "version": "==3.7.8"
+            "version": "==3.7.9"
         },
         "idna": {
             "hashes": [
@@ -446,26 +454,29 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:02b260c8deb80db09325b99edf62ae344ce9bc64d68b7a634410b8e9a568edbf",
-                "sha256:18f9c401083a4ba6e162355873f906315332ea7035803d0fd8166051e3d402e3",
-                "sha256:1f2c6209a8917c525c1e2b55a716135ca4658a3042b5122d4e3413a4030c26ce",
-                "sha256:2f06d97f0ca0f414f6b707c974aaf8829c2292c1c497642f63824119d770226f",
-                "sha256:616c94f8176808f4018b39f9638080ed86f96b55370b5a9463b2ee5c926f6c5f",
-                "sha256:63b91e30ef47ef68a30f0c3c278fbfe9822319c15f34b7538a829515b84ca2a0",
-                "sha256:77b454f03860b844f758c5d5c6e5f18d27de899a3db367f4af06bec2e6013a8e",
-                "sha256:83fe27ba321e4cfac466178606147d3c0aa18e8087507caec78ed5a966a64905",
-                "sha256:84742532d39f72df959d237912344d8a1764c2d03fe58beba96a87bfa11a76d8",
-                "sha256:874ebf3caaf55a020aeb08acead813baf5a305927a71ce88c9377970fe7ad3c2",
-                "sha256:9f5caf2c7436d44f3cec97c2fa7791f8a675170badbfa86e1992ca1b84c37009",
-                "sha256:a0c8758d01fcdfe7ae8e4b4017b13552efa7f1197dd7358dc9da0576f9d0328a",
-                "sha256:a4def978d9d28cda2d960c279318d46b327632686d82b4917516c36d4c274512",
-                "sha256:ad4f4be843dace866af5fc142509e9b9817ca0c59342fdb176ab6ad552c927f5",
-                "sha256:ae33dd198f772f714420c5ab698ff05ff900150486c648d29951e9c70694338e",
-                "sha256:b4a2b782b8a8c5522ad35c93e04d60e2ba7f7dcb9271ec8e8c3e08239be6c7b4",
-                "sha256:c462eb33f6abca3b34cdedbe84d761f31a60b814e173b98ede3c81bb48967c4f",
-                "sha256:fd135b8d35dfdcdb984828c84d695937e58cc5f49e1c854eb311c4d6aa03f4f1"
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
-            "version": "==1.4.2"
+            "version": "==1.4.3"
         },
         "mccabe": {
             "hashes": [

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -8,9 +8,10 @@ import logging
 import re
 
 import arrow
-import authl.flask
 import flask
 import werkzeug.exceptions
+
+import authl.flask
 
 from . import (caching, config, image, index, maintenance, model, rendering,
                user, utils, view)
@@ -140,13 +141,13 @@ accordingly.")
 
         caching.init_app(self, config.cache)
 
-        authl.flask.setup(self, config.auth,
-                          login_path='/_login',
-                          login_name='login',
-                          callback_path='/_cb',
-                          tester_path='/_ct',
-                          force_ssl=auth_force_https,
-                          login_render_func=rendering.render_login_form)
+        self.authl = authl.flask.AuthlFlask(self, config.auth,
+                                            login_path='/_login',
+                                            login_name='login',
+                                            callback_path='/_cb',
+                                            tester_path='/_ct',
+                                            force_ssl=auth_force_https,
+                                            login_render_func=rendering.render_login_form)
 
         def logout(redir=''):
             """ Log out from the thing """

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -8,10 +8,9 @@ import logging
 import re
 
 import arrow
+import authl.flask
 import flask
 import werkzeug.exceptions
-
-import authl.flask
 
 from . import (caching, config, image, index, maintenance, model, rendering,
                user, utils, view)

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,9 @@ setup(
     package_data={'publ': ['default_template/*']},
 
     install_requires=[
-        'arrow>=0.13.0',
+        'arrow',
         'atomicwrites',
-        'authl',
+        'authl>=0.2.3',
         'awesome-slugify',
         'flask',
         'flask_caching',

--- a/tests/templates/auth/unauthorized.html
+++ b/tests/templates/auth/unauthorized.html
@@ -11,7 +11,9 @@
     <div id="login">
         <h1>Authorization Pending</h1>
         <div id="notify">
-        <p>Sorry, <code>{{user.name}}</code>, you don't currently have access to this page. You can try <a href="{{logout}}">logging in as someone else</a> or <a href="{{logout(category.link if category else None)}}">logging out entirely</a>.</p>
+        <p>User {{user.name}}, groups=[{{', '.join(user.groups)}}]</p>
+        <p><a href="{{logout}}">log in as someone else</a>, <a href="{{logout(category.link if category else None)}}">log out entirely</a>.</p>
+
     </div>
         <div id="powered">
             <p>Powered by <a href="https://github.com/PlaidWeb/Authl">Authl</a></p>

--- a/tests/templates/err/403.html
+++ b/tests/templates/err/403.html
@@ -1,0 +1,1 @@
+Yo, 403 error, sup?

--- a/tests/templates/login.html
+++ b/tests/templates/login.html
@@ -16,6 +16,14 @@ The current user is {{user.name}}, who belongs to groups [{{', '.join(user.group
 Nobody is currently logged in.
 {% endif %}</p>
 
+<p>Some other Authl config stuff:</p>
+
+<ul>
+    <li>Login URL: {{login_url}}</li>
+    <li>API tester: {{test_url}}</li>
+    <li>Redirect path: '{{redir}}'</li>
+</ul>
+
 <form method="GET" action="{{login_url}}" novalidate>
     <input type="url" name="me" placeholder="A credential goes here">
 </form>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Treat the need to log in as a 401 error; Closes #294 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
By treating the page as a 401 error, we are able to eventually add in a `WWW-Authenticate:` header to support AutoAuth flows.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Usual battery of manual auth tests
