### PR TITLE
Actually stash the user record into the request globals

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -23,8 +23,8 @@ EXTENSION_MAP = {
     '.html': 'text/html; charset=utf-8',
     '.xml': 'application/xml',
     '.json': 'application/json',
-    '.css': 'text/css',
-    '.txt': 'text/plain'
+    '.css': 'text/css; charset=utf-8',
+    '.txt': 'text/plain; charset=utf-8'
 }
 
 # Headers for responses that shouldn't be cached

--- a/publ/user.py
+++ b/publ/user.py
@@ -88,17 +88,17 @@ class User(caching.Memoizable):
         return config.admin_group and config.admin_group in self.groups
 
 
-def _get_user_id():
-    if flask.session.get('me'):
-        return flask.session['me']
-
-    return None
-
-
 @utils.stash('user')
 def get_active():
     """ Get the active user """
+    def _get_user_id():
+        if flask.session.get('me'):
+            return flask.session['me']
+
+        return None
+
     user_id = _get_user_id()
+    LOGGER.debug("Got user id: %s", user_id)
     return User(user_id) if user_id else None
 
 

--- a/publ/user.py
+++ b/publ/user.py
@@ -11,7 +11,7 @@ import flask
 from pony import orm
 from werkzeug.utils import cached_property
 
-from . import caching, config, model
+from . import caching, config, model, utils
 
 LOGGER = logging.getLogger(__name__)
 
@@ -88,12 +88,18 @@ class User(caching.Memoizable):
         return config.admin_group and config.admin_group in self.groups
 
 
-def get_active():
-    """ Get the active user and add it to the request stash """
+def _get_user_id():
     if flask.session.get('me'):
-        return User(flask.session['me'])
+        return flask.session['me']
 
     return None
+
+
+@utils.stash('user')
+def get_active():
+    """ Get the active user """
+    user_id = _get_user_id()
+    return User(user_id) if user_id else None
 
 
 @orm.db_session(immediate=True)

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -6,6 +6,7 @@ import html.parser
 import logging
 import os
 import re
+import typing
 import urllib.parse
 
 import arrow
@@ -392,3 +393,20 @@ def auth_link(endpoint):
         return flask.url_for(endpoint, redir=redir, **kwargs)
 
     return CallableProxy(endpoint_link)
+
+
+def stash(key: str) -> typing.Callable:
+    """ Decorator to memoize a function onto the global context.
+
+    :param str key: The memoization key
+    """
+
+    def decorator(func: typing.Callable) -> typing.Callable:
+        def wrapped_func(*args, **kwargs):
+            if key not in flask.g:
+                val = func(*args, **kwargs)
+                setattr(flask.g, key, val)
+                return val
+            return flask.g.get(key)
+        return wrapped_func
+    return decorator

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -403,10 +403,10 @@ def stash(key: str) -> typing.Callable:
 
     def decorator(func: typing.Callable) -> typing.Callable:
         def wrapped_func(*args, **kwargs):
-            if key not in flask.g:
-                val = func(*args, **kwargs)
-                setattr(flask.g, key, val)
-                return val
-            return flask.g.get(key)
+            if key in flask.g:
+                return flask.g.get(key)
+            val = func(*args, **kwargs)
+            setattr(flask.g, key, val)
+            return val
         return wrapped_func
     return decorator

--- a/tests/templates/_entry.html
+++ b/tests/templates/_entry.html
@@ -71,8 +71,6 @@
             <section id="webmentions"></section>
         </div>
     </div>
-    </div>
-    </div>
 
 </body>
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Stashes the active user on the request stash

## Detailed description

Previously we were re-creating the user object from the session every time the user object was needed; future user verification may be a multi-step networked process which would make this incredibly inefficient.

For this change it also adds a utility decorator to memoize results to the stash, which might be useful somewhere else down the road.

## Test plan

Verified that the `get_active` function is only being  called once per page request

## Got a site to show off?

<!-- If so, link to it here! -->
