### PR TITLE
Implement Authorized: header support

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -6,7 +6,6 @@ import logging
 import os
 
 import flask
-import itsdangerous
 import werkzeug.exceptions as http_error
 from flask import make_response, redirect, request, send_file, url_for
 from pony import orm
@@ -176,12 +175,11 @@ def render_exception(error):
 
     headers = {**NO_CACHE}
 
-    bad_token = isinstance(error, itsdangerous.BadData)
-    if bad_token:
-        flask.g.token_error = error.message
-    if bad_token or isinstance(error, http_error.Unauthorized):
+    if isinstance(error, http_error.Unauthorized):
         from flask import current_app as app
         flask.g.needs_token = True
+        if 'token_error' in flask.g:
+            flask.flash(flask.g.token_error)
         return app.authl.render_login_form(destination=utils.redir_path()), 401, headers
 
     if isinstance(error, http_error.HTTPException):

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -78,4 +78,10 @@ def token_endpoint():
 
 def parse_token(token: str) -> str:
     """ Parse a bearer token to get the stored data """
-    return signer().loads(token, max_age=config.max_token_age)
+    try:
+        return signer().loads(token, max_age=config.max_token_age)
+    except itsdangerous.BadData as error:
+        LOGGER.error("Got token parse error: %s", error)
+        flask.g.user = None
+        flask.g.token_error = error.message
+        raise http_error.Unauthorized(error.message)

--- a/publ/user.py
+++ b/publ/user.py
@@ -110,14 +110,14 @@ class User(caching.Memoizable):
 @utils.stash('user')
 def get_active():
     """ Get the active user """
-    if flask.session.get('me'):
-        return User(flask.session['me'], 'session')
-
     if 'Authorization' in flask.request.headers:
         parts = flask.request.headers['Authorization'].split()
         if parts[0].lower() == 'bearer':
             token = tokens.parse_token(parts[1])
             return User(token['me'], 'token', token.get('scope'))
+
+    if flask.session.get('me'):
+        return User(flask.session['me'], 'session')
 
     return None
 

--- a/tests/templates/login.html
+++ b/tests/templates/login.html
@@ -1,40 +1,45 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <title>Login required</title>
     <link rel="stylesheet" href="{{url_for('login',asset='css')}}">
 </head>
+
 <body>
-
-<div id="login">
-<p>This is a crappy-looking login page for Publ's tests. It is purposefully
-    sparse.
-
-{% if user %}
-The current user is {{user.name}}, who belongs to groups [{{', '.join(user.groups)}}].
-{%else%}
-Nobody is currently logged in.
-{% endif %}</p>
-
-<p>Some other Authl config stuff:</p>
-
-<ul>
-    <li>Login URL: {{login_url}}</li>
-    <li>API tester: {{test_url}}</li>
-    <li>Redirect path: '{{redir}}'</li>
-</ul>
-
-<form method="GET" action="{{login_url}}" novalidate>
-    <input type="url" name="me" placeholder="A credential goes here">
-</form>
-
-<p>Accepted auth methods:</p>
-<ul>
-    {% for handler in auth.handlers %}
-    <li>{{handler.service_name}}: {{handler.description|safe}}</li>
-    {% endfor %}
-</ul>
-</div>
-
+    <div id="login">
+        <p>This is a crappy-looking login page for Publ's tests. It is purposefully
+            sparse.
+            {% if user %}
+            The current user is {{user.name}}, who belongs to groups [{{', '.join(user.groups)}}].
+            {%else%}
+            Nobody is currently logged in.
+            {% endif %}</p>
+        <p>Some other Authl config stuff:</p>
+        <ul>
+            <li>Login URL: {{login_url}}</li>
+            <li>API tester: {{test_url}}</li>
+            <li>Redirect path: '{{redir}}'</li>
+        </ul>
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+        <ul class="flashes">
+            {% for message in messages %}
+            <li>{{ message }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        {% endwith %}
+        <form method="GET" action="{{login_url}}" novalidate>
+            <input type="url" name="me" placeholder="A credential goes here">
+        </form>
+        <p>Accepted auth methods:</p>
+        <ul>
+            {% for handler in auth.handlers %}
+            <li>{{handler.service_name}}: {{handler.description|safe}}</li>
+            {% endfor %}
+        </ul>
+    </div>
 </body>
+
 </html>

--- a/tests/templates/userinfo.html
+++ b/tests/templates/userinfo.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>User information</title>
+</head>
+
+<body>
+    {% if user %}
+    <ul>
+        <li>name: {{user.name}}</li>
+        <li>auth type: {{user.auth_type}}</li>
+        <li>scope: {{user.scope}}</li>
+        <li>groups: {{user.groups}}</li>
+        <li>auth_groups: {{user.auth_groups}}</li>
+        <li>is_admin: {{user.is_admin}}</li>
+    </ul>
+    {% else %}
+    No active user
+    {% endif %}
+</body>
+
+</html>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Support the `Authorized:` header with a token type of `Bearer`; closes #295 

## Detailed description

If there's an `Authorized` header on the request, attempt to parse and verify it to get the user information. If it succeeds, treat that pageview as having authorization. Otherwise, throw an appropriate error about the failed parse even if the request is for a public resource.

[Relevant error case discussion](https://chat.indieweb.org/dev/2019-10-29#t1572387697863700)

This change also introduces the concept of authentication provenance for the user, as well as user scope.

## Test plan

Added `/userinfo.html` on tests to check the current user authorization mode.

Used https://gimme-a-token.5eb.nl/ to test the success and failure cases for Bearer authorization; example commands:

```
curl http://localhost:5000/userinfo -H 'Authorization: Bearer TOKEN_GOES_HERE'
```

(replacing the `TOKEN_GOES_HERE` with a valid or invalid one as appropriate to the test)
