### PR TITLE
Add authentication headers for restricted content

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -177,6 +177,7 @@ accordingly.")
             self.add_url_rule(route, 'admin', rendering.admin_dashboard)
 
         self.before_request(user.log_user)
+        self.after_request(tokens.inject_auth_headers)
 
         self._maint = maintenance.Maintenance()
 

--- a/publ/view.py
+++ b/publ/view.py
@@ -8,7 +8,7 @@ import flask
 from pony import orm
 from werkzeug.utils import cached_property
 
-from . import caching, model, queries, user, utils
+from . import caching, model, queries, tokens, user, utils
 from .entry import Entry
 
 LOGGER = logging.getLogger(__name__)
@@ -136,6 +136,9 @@ class View(caching.Memoizable):
                     if not auth and unauthorized is not True:
                         unauthorized -= 1
 
+                if not auth:
+                    tokens.request(cur_user)
+
             return result
 
         return utils.CallableProxy(_entries)
@@ -155,6 +158,7 @@ class View(caching.Memoizable):
                     break
 
                 if not record.is_authorized(cur_user):
+                    tokens.request(cur_user)
                     result.append(Entry(record))
 
             return result

--- a/tests/content/auth/upgrade/private 0.md
+++ b/tests/content/auth/upgrade/private 0.md
@@ -1,0 +1,6 @@
+Title: private 0
+Auth: *
+Date: 2019-10-29 20:00:03-07:00
+UUID: a76385d0-1fc5-55a8-b432-d706cba6cda3
+Entry-ID: 1360
+

--- a/tests/content/auth/upgrade/private 1.md
+++ b/tests/content/auth/upgrade/private 1.md
@@ -1,0 +1,6 @@
+Title: private 1
+Auth: *
+Date: 2019-10-29 20:29:03-07:00
+Entry-ID: 1497
+UUID: a76385d0-1fc5-55a8-b432-d706cba6cda3
+

--- a/tests/content/auth/upgrade/private 2.md
+++ b/tests/content/auth/upgrade/private 2.md
@@ -1,0 +1,6 @@
+Title: private 2
+Auth: *
+Date: 2019-10-29 20:29:13-07:00
+Entry-ID: 6
+UUID: 9e565827-2482-520b-9c81-83dc1038a063
+

--- a/tests/content/auth/upgrade/private 3.md
+++ b/tests/content/auth/upgrade/private 3.md
@@ -1,0 +1,6 @@
+Title: private 3
+Auth: *
+Date: 2019-10-29 20:29:20-07:00
+Entry-ID: 1899
+UUID: 587311f6-9800-5c9c-9e3b-191df1147ff3
+

--- a/tests/content/auth/upgrade/public 1.md
+++ b/tests/content/auth/upgrade/public 1.md
@@ -1,0 +1,6 @@
+Title: public 1
+Date: 2019-10-29 20:28:31-07:00
+Entry-ID: 2017
+UUID: 65ce5210-83a4-594c-9b02-3188e454dc82
+
+should have upgrade headers because of private 0

--- a/tests/content/auth/upgrade/public 2.md
+++ b/tests/content/auth/upgrade/public 2.md
@@ -1,0 +1,6 @@
+Title: public 2
+Date: 2019-10-29 20:28:41-07:00
+Entry-ID: 2143
+UUID: 17e22ae9-4c10-5bd5-8775-5424da7277ee
+
+should have no upgrade headers

--- a/tests/content/auth/upgrade/public 3.md
+++ b/tests/content/auth/upgrade/public 3.md
@@ -1,0 +1,6 @@
+Title: public 3
+Date: 2019-10-29 20:28:47-07:00
+Entry-ID: 1662
+UUID: 8fcb9376-1851-5ef1-b4e8-4dfe2f047076
+
+should have upgrade headers because of private 1


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Add the appropriate `WWW-Authenticate` headers when there's hidden content that could be visible; closes #293; closes #292 


## Detailed description

On a page where a change in authentication might cause an increase in visibility, a `WWW-Authenticate` and `Link` header get added.

The logic for when they get added is:

* on any `401 Unauthorized` response  (including those caused by a bad/invalid token)
* on any page where an attempt is made to access an unauthorized entry, but only if there is no active user

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Both logged-in and logged-out, looked at the response headers on the `/auth/` view, the `/auth/upgrade/` individual entries, and on `/auth/562-admin-only`.

## Got a site to show off?

<!-- If so, link to it here! -->
