### PR TITLE
Upgrade 401 login pages to https if so configured

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -176,6 +176,13 @@ def render_exception(error):
 
     if isinstance(error, http_error.Unauthorized):
         from flask import current_app as app
+
+        force_ssl = config.auth.get('AUTH_FORCE_HTTPS')
+        if force_ssl and request.scheme != 'https':
+            return redirect(utils.secure_link(request.endpoint,
+                                              **request.view_args,
+                                              **request.args))
+
         flask.g.needs_token = True
         if 'token_error' in flask.g:
             flask.flash(flask.g.token_error)

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -378,7 +378,7 @@ def redir_path(path=None):
 def secure_link(endpoint, *args, **kwargs):
     """ flask.url_for except it will force the link to be secure if we are
     configured with AUTH_FORCE_HTTPS """
-    force_ssl = config.auth.get('AUTH_FORCE_HTTPS', config.auth.get('AUTH_FORCE_SSL'))
+    force_ssl = config.auth.get('AUTH_FORCE_HTTPS')
 
     if force_ssl and flask.request.scheme != 'https':
         kwargs = {**kwargs,


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Upgrade 401 Unauthorized login pages to https if https. Fixes #303 

## Detailed description

Not much more to say.

## Test plan

Ran locally with `AUTH_FORCE_HTTPS`, a redirect on a private entry happened. Turned that option off, the redirect stopped happening.

