### PR TITLE
Show all images in a gallery, even if skipped

### DIFF
--- a/publ/cards.py
+++ b/publ/cards.py
@@ -49,10 +49,10 @@ class MarkdownCardParser(misaka.BaseRenderer):
 
         alt, container_args = image.parse_alt_text(alt)
 
-        spec_list, _ = image.get_spec_list(image_specs, container_args)
+        spec_list = image.get_spec_list(image_specs, container_args)
 
-        for spec in spec_list:
-            if not spec:
+        for (spec, show) in spec_list:
+            if not spec or not show:
                 continue
 
             self._out.images.append(self._render_image(spec, alt))

--- a/publ/image/image.py
+++ b/publ/image/image.py
@@ -163,10 +163,8 @@ class Image(ABC):
         return self()
 
     def _wrap_link_target(self, kwargs, text, title):
-        if kwargs.get('link'):
-            if not text:
-                # don't generate a link around empty text (and don't let this
-                # fall through to the gallery_id branch)
+        if kwargs.get('link') is not None:
+            if not text or kwargs['link'] is False:
                 return text
 
             return '{}{}</a>'.format(

--- a/publ/image/image.py
+++ b/publ/image/image.py
@@ -75,7 +75,7 @@ class Image(ABC):
 
         return attrs
 
-    def get_img_tag(self, title=None, alt_text=None, **kwargs):
+    def get_img_tag(self, title=None, alt_text=None, _show_thumbnail=True, **kwargs):
         """ Build a <img> tag for the image with the specified options.
 
         Returns: an HTML fragment. """
@@ -93,11 +93,16 @@ class Image(ABC):
             if title:
                 attrs['title'] = title
 
+            if _show_thumbnail:
+                thumb = utils.make_tag(
+                    'img', attrs, start_end=kwargs.get('xhtml'))
+            else:
+                thumb = ''
+
             return flask.Markup(
                 self._wrap_link_target(
                     kwargs,
-                    utils.make_tag(
-                        'img', attrs, start_end=kwargs.get('xhtml')),
+                    thumb,
                     title))
         except FileNotFoundError as error:
             text = '<span class="error">Image not found: <code>{}</code>'.format(
@@ -158,7 +163,12 @@ class Image(ABC):
         return self()
 
     def _wrap_link_target(self, kwargs, text, title):
-        if 'link' in kwargs and kwargs['link'] is not None:
+        if kwargs.get('link'):
+            if not text:
+                # don't generate a link around empty text (and don't let this
+                # fall through to the gallery_id branch)
+                return text
+
             return '{}{}</a>'.format(
                 utils.make_tag(
                     'a', {
@@ -169,7 +179,7 @@ class Image(ABC):
                     }),
                 text)
 
-        if 'gallery_id' in kwargs and kwargs['gallery_id'] is not None:
+        if kwargs.get('gallery_id'):
             return '{}{}</a>'.format(
                 self._fullsize_link_tag(kwargs, title), text)
 
@@ -191,11 +201,11 @@ class Image(ABC):
         return img_fullsize
 
     def _fullsize_link_tag(self, kwargs, title):
-        """ Render a <a href> that points to the fullsize rendition specified """
+        """ Render an <a href> that points to the fullsize rendition specified """
 
         return utils.make_tag('a', {
             'href': self.get_fullsize(kwargs),
-            'data-lightbox': kwargs['gallery_id'],
+            'data-lightbox': kwargs.get('gallery_id', False),
             'title': title or False,
             'class': kwargs.get('link_class', False)
         })

--- a/tests/content/images/limits.md
+++ b/tests/content/images/limits.md
@@ -1,0 +1,34 @@
+Title: Gallery with limits
+Date: 2019-11-15 11:56:52-08:00
+Entry-ID: 1864
+UUID: 24428234-e819-5c32-9197-2d245c809971
+
+Show only the third image on the index, full gallery in entry:
+
+![{index_count=1,count_offset=2,index_link='1864',gallery_id='truncated'}](rawr.jpg "one" | rawr.jpg "two" | rawr.jpg "three" | rawr.jpg "four" | rawr.jpg "five")
+
+.....
+
+No limit:
+
+![](rawr.jpg "one" | rawr.jpg "two" | rawr.jpg "three" | rawr.jpg "four" | rawr.jpg "five")
+
+`count=3`
+
+![{count=3,more_text="count={count},remain={remain}"}](rawr.jpg "one" | rawr.jpg "two" | rawr.jpg "three" | rawr.jpg "four" | rawr.jpg "five")
+
+`count_offset=2`
+
+![{count_offset=2,more_text="count={count},remain={remain}"}](rawr.jpg "one" | rawr.jpg "two" | rawr.jpg "three" | rawr.jpg "four" | rawr.jpg "five")
+
+`count=3,count_offset=2`
+
+![{count=3,count_offset=2,more_text="count={count},remain={remain}"}](rawr.jpg "one" | rawr.jpg "two" | rawr.jpg "three" | rawr.jpg "four" | rawr.jpg "five")
+
+`link='/',count=3,count_offset=2`
+
+![{link='/',count=3,count_offset=2,more_text="count={count},remain={remain}"}](rawr.jpg "one" | rawr.jpg "two" | rawr.jpg "three" | rawr.jpg "four" | rawr.jpg "five")
+
+`gallery_id='test',count=2,count_offset=1`
+
+![{gallery_id='test',count=2,count_offset=2,more_text="count={count},remain={remain}"}](rawr.jpg "one" | rawr.jpg "two" | rawr.jpg "three" | rawr.jpg "four" | rawr.jpg "five")


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

If an image in a gallery is being skipped due to `count` or `count_offset`, still render the fullsize image and add it to the gallery set. Closes #308 


<!-- Summary of the PR; please link to any issue(s) that this solves -->

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

In a context where there's a `gallery_id` and a `link`, this does *not* generate the fullsize renditions, as there would be no point to that anyway.


## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
see test 1864

## Got a site to show off?

<!-- If so, link to it here! -->
