### PR TITLE
Improve footnote references

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -43,6 +43,7 @@ class Entry(caching.Memoizable):
 
         LOGGER.debug('init entry %d', record.id)
         self._record = record   # index record
+        self._footnotes = []    # deferred footnotes
 
     def __lt__(self, other):
         # pylint:disable=protected-access
@@ -292,16 +293,25 @@ class Entry(caching.Memoizable):
     def body(self):
         """ Get the above-the-fold entry body text """
         body, _, is_markdown = self._entry_content
-        return TrueCallableProxy(
-            lambda **kwargs: self._get_markup(body, is_markdown, **kwargs)
-        ) if body else CallableProxy(None)
+
+        def _body(**kwargs):
+            kwargs = {'footnotes_defer': True, **kwargs}
+            if 'footnotes_link' not in kwargs:
+                kwargs['footnotes_link'] = self.link(absolute=kwargs.get('absolute'))
+            return self._get_markup(body, is_markdown, **kwargs)
+
+        return TrueCallableProxy(_body) if body else CallableProxy(None)
 
     @cached_property
     def more(self):
         """ Get the below-the-fold entry body text """
         _, more, is_markdown = self._entry_content
         return TrueCallableProxy(
-            lambda **kwargs: self._get_markup(more, is_markdown, **kwargs)
+            lambda **kwargs: self._get_markup(
+                more, is_markdown,
+                **{'footnotes_defer': False,
+                   'footnotes_link': False,
+                   **kwargs})
         ) if more else CallableProxy(None)
 
     @cached_property
@@ -372,8 +382,10 @@ class Entry(caching.Memoizable):
         if is_markdown:
             return markdown.to_html(
                 text,
-                kwargs,
-                search_path=self.search_path)
+                footnote_buffer=self._footnotes,
+                args=kwargs,
+                search_path=self.search_path,
+                entry_id=self._record.id)
 
         return html_entry.process(
             text,

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -306,13 +306,13 @@ class Entry(caching.Memoizable):
     def more(self):
         """ Get the below-the-fold entry body text """
         _, more, is_markdown = self._entry_content
-        return TrueCallableProxy(
-            lambda **kwargs: self._get_markup(
-                more, is_markdown,
-                **{'footnotes_defer': False,
-                   'footnotes_link': False,
-                   **kwargs})
-        ) if more else CallableProxy(None)
+
+        def _more(**kwargs):
+            if kwargs.get('absolute') and 'footnote_links' not in kwargs:
+                kwargs = {'footnotes_link': self.link(absolute=True), **kwargs}
+            return self._get_markup(more, is_markdown, **kwargs)
+
+        return TrueCallableProxy(_more) if more else CallableProxy(None)
 
     @cached_property
     def card(self):

--- a/tests/content/footnotes.md
+++ b/tests/content/footnotes.md
@@ -1,0 +1,83 @@
+Title: Footnotes
+Date: 2019-11-25 00:31:41-08:00
+Entry-ID: 1063
+UUID: 8718a59e-b8eb-5f3f-aa84-a2f9935b33e6
+
+Here is a footnote in the body.[^body1]
+
+Here is another footnote in the body.[^body2]
+
+[^body1]: hi[^nestbody]
+
+[^body2]: hello
+
+[^nestbody]: This is nested in the body
+
+This footnote will be an invalid reference.[^invalidmore]
+
+[^invalidbody]: more can't reference body; this footnote shouldn't appear
+
+.....
+
+
+[^invalidmore]: body can't reference more; this footnote shouldn't appear
+
+
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet aliquet dapibus. Vivamus augue felis, cursus id convallis non, pretium semper tortor. Quisque condimentum eleifend hendrerit. Nam gravida erat pellentesque eleifend scelerisque. Ut tempus quam a augue cursus, a varius felis cursus. Aenean at sapien id risus commodo imperdiet sed eu est. Mauris sodales efficitur nulla vitae imperdiet. Etiam semper libero congue mauris venenatis maximus. Pellentesque eu augue justo.
+
+Ut euismod aliquet sapien non semper. Proin tellus lorem, rhoncus vitae turpis in, tempor scelerisque sapien. Morbi vel facilisis nisl. Nam auctor viverra lacus non scelerisque. Nullam id ligula ut mi egestas sodales. Morbi dapibus nunc ut augue aliquam feugiat. Proin ante magna, efficitur at elit consectetur, maximus bibendum sapien. Aenean non accumsan eros. Praesent eu mi risus. Vestibulum ut imperdiet augue. Quisque accumsan ex velit, sit amet mattis leo tristique vitae.
+
+Suspendisse potenti. Duis dolor dui, pretium non ex a, molestie placerat metus. Aenean sagittis velit sapien, quis semper velit molestie id. Fusce eu magna odio. Nunc pellentesque fermentum velit vitae congue. Fusce porttitor lacus quis velit ultricies pharetra. Cras ullamcorper ac arcu at tempor. Donec vel leo ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In consequat nisl facilisis ante tempus, at condimentum turpis fermentum.
+
+Maecenas vel feugiat turpis. Mauris et tincidunt ex, quis eleifend odio. Nunc vulputate imperdiet sollicitudin. Vestibulum varius erat leo, sed luctus turpis aliquet eget. Nullam interdum erat quis leo varius, sit amet placerat ante pellentesque. Morbi et turpis eu velit elementum mattis ac mollis diam. Vestibulum quam nunc, rhoncus quis mi in, commodo accumsan metus. Donec tristique mi in consectetur accumsan. Pellentesque purus nunc, feugiat vitae fermentum et, rhoncus ut lectus. Praesent purus lectus, aliquam ut pharetra non, tempus rhoncus nibh. Pellentesque eget nibh non massa ultricies facilisis eget sed tellus. Aenean id dignissim ex. In consequat, mi vitae volutpat efficitur, justo enim suscipit mi, eu egestas mauris est ac nibh. Sed ut purus et nunc suscipit tempor.
+
+Mauris aliquam magna justo, at ullamcorper massa fermentum vel. Phasellus nec vehicula neque, quis tincidunt sapien. Mauris vehicula eros eu lectus feugiat, id posuere libero ullamcorper. Pellentesque fermentum vel felis vitae imperdiet. Nam vitae arcu ante. Morbi posuere sollicitudin viverra. Fusce a magna eget ante commodo lobortis in quis augue.
+
+Here is a footnote in the more.[^more1]
+
+This footnote will also be an invalid reference.[^invalidbody]
+
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet aliquet dapibus. Vivamus augue felis, cursus id convallis non, pretium semper tortor. Quisque condimentum eleifend hendrerit. Nam gravida erat pellentesque eleifend scelerisque. Ut tempus quam a augue cursus, a varius felis cursus. Aenean at sapien id risus commodo imperdiet sed eu est. Mauris sodales efficitur nulla vitae imperdiet. Etiam semper libero congue mauris venenatis maximus. Pellentesque eu augue justo.
+
+Ut euismod aliquet sapien non semper. Proin tellus lorem, rhoncus vitae turpis in, tempor scelerisque sapien. Morbi vel facilisis nisl. Nam auctor viverra lacus non scelerisque. Nullam id ligula ut mi egestas sodales. Morbi dapibus nunc ut augue aliquam feugiat. Proin ante magna, efficitur at elit consectetur, maximus bibendum sapien. Aenean non accumsan eros. Praesent eu mi risus. Vestibulum ut imperdiet augue. Quisque accumsan ex velit, sit amet mattis leo tristique vitae.
+
+Suspendisse potenti. Duis dolor dui, pretium non ex a, molestie placerat metus. Aenean sagittis velit sapien, quis semper velit molestie id. Fusce eu magna odio. Nunc pellentesque fermentum velit vitae congue. Fusce porttitor lacus quis velit ultricies pharetra. Cras ullamcorper ac arcu at tempor. Donec vel leo ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In consequat nisl facilisis ante tempus, at condimentum turpis fermentum.
+
+Maecenas vel feugiat turpis. Mauris et tincidunt ex, quis eleifend odio. Nunc vulputate imperdiet sollicitudin. Vestibulum varius erat leo, sed luctus turpis aliquet eget. Nullam interdum erat quis leo varius, sit amet placerat ante pellentesque. Morbi et turpis eu velit elementum mattis ac mollis diam. Vestibulum quam nunc, rhoncus quis mi in, commodo accumsan metus. Donec tristique mi in consectetur accumsan. Pellentesque purus nunc, feugiat vitae fermentum et, rhoncus ut lectus. Praesent purus lectus, aliquam ut pharetra non, tempus rhoncus nibh. Pellentesque eget nibh non massa ultricies facilisis eget sed tellus. Aenean id dignissim ex. In consequat, mi vitae volutpat efficitur, justo enim suscipit mi, eu egestas mauris est ac nibh. Sed ut purus et nunc suscipit tempor.
+
+Mauris aliquam magna justo, at ullamcorper massa fermentum vel. Phasellus nec vehicula neque, quis tincidunt sapien. Mauris vehicula eros eu lectus feugiat, id posuere libero ullamcorper. Pellentesque fermentum vel felis vitae imperdiet. Nam vitae arcu ante. Morbi posuere sollicitudin viverra. Fusce a magna eget ante commodo lobortis in quis augue.
+
+Another one.[^more2]
+
+
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet aliquet dapibus. Vivamus augue felis, cursus id convallis non, pretium semper tortor. Quisque condimentum eleifend hendrerit. Nam gravida erat pellentesque eleifend scelerisque. Ut tempus quam a augue cursus, a varius felis cursus. Aenean at sapien id risus commodo imperdiet sed eu est. Mauris sodales efficitur nulla vitae imperdiet. Etiam semper libero congue mauris venenatis maximus. Pellentesque eu augue justo.
+
+Ut euismod aliquet sapien non semper. Proin tellus lorem, rhoncus vitae turpis in, tempor scelerisque sapien. Morbi vel facilisis nisl. Nam auctor viverra lacus non scelerisque. Nullam id ligula ut mi egestas sodales. Morbi dapibus nunc ut augue aliquam feugiat. Proin ante magna, efficitur at elit consectetur, maximus bibendum sapien. Aenean non accumsan eros. Praesent eu mi risus. Vestibulum ut imperdiet augue. Quisque accumsan ex velit, sit amet mattis leo tristique vitae.
+
+Suspendisse potenti. Duis dolor dui, pretium non ex a, molestie placerat metus. Aenean sagittis velit sapien, quis semper velit molestie id. Fusce eu magna odio. Nunc pellentesque fermentum velit vitae congue. Fusce porttitor lacus quis velit ultricies pharetra. Cras ullamcorper ac arcu at tempor. Donec vel leo ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In consequat nisl facilisis ante tempus, at condimentum turpis fermentum.
+
+Maecenas vel feugiat turpis. Mauris et tincidunt ex, quis eleifend odio. Nunc vulputate imperdiet sollicitudin. Vestibulum varius erat leo, sed luctus turpis aliquet eget. Nullam interdum erat quis leo varius, sit amet placerat ante pellentesque. Morbi et turpis eu velit elementum mattis ac mollis diam. Vestibulum quam nunc, rhoncus quis mi in, commodo accumsan metus. Donec tristique mi in consectetur accumsan. Pellentesque purus nunc, feugiat vitae fermentum et, rhoncus ut lectus. Praesent purus lectus, aliquam ut pharetra non, tempus rhoncus nibh. Pellentesque eget nibh non massa ultricies facilisis eget sed tellus. Aenean id dignissim ex. In consequat, mi vitae volutpat efficitur, justo enim suscipit mi, eu egestas mauris est ac nibh. Sed ut purus et nunc suscipit tempor.
+
+Mauris aliquam magna justo, at ullamcorper massa fermentum vel. Phasellus nec vehicula neque, quis tincidunt sapien. Mauris vehicula eros eu lectus feugiat, id posuere libero ullamcorper. Pellentesque fermentum vel felis vitae imperdiet. Nam vitae arcu ante. Morbi posuere sollicitudin viverra. Fusce a magna eget ante commodo lobortis in quis augue.
+
+
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet aliquet dapibus. Vivamus augue felis, cursus id convallis non, pretium semper tortor. Quisque condimentum eleifend hendrerit. Nam gravida erat pellentesque eleifend scelerisque. Ut tempus quam a augue cursus, a varius felis cursus. Aenean at sapien id risus commodo imperdiet sed eu est. Mauris sodales efficitur nulla vitae imperdiet. Etiam semper libero congue mauris venenatis maximus. Pellentesque eu augue justo.
+
+Ut euismod aliquet sapien non semper. Proin tellus lorem, rhoncus vitae turpis in, tempor scelerisque sapien. Morbi vel facilisis nisl. Nam auctor viverra lacus non scelerisque. Nullam id ligula ut mi egestas sodales. Morbi dapibus nunc ut augue aliquam feugiat. Proin ante magna, efficitur at elit consectetur, maximus bibendum sapien. Aenean non accumsan eros. Praesent eu mi risus. Vestibulum ut imperdiet augue. Quisque accumsan ex velit, sit amet mattis leo tristique vitae.
+
+Suspendisse potenti. Duis dolor dui, pretium non ex a, molestie placerat metus. Aenean sagittis velit sapien, quis semper velit molestie id. Fusce eu magna odio. Nunc pellentesque fermentum velit vitae congue. Fusce porttitor lacus quis velit ultricies pharetra. Cras ullamcorper ac arcu at tempor. Donec vel leo ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In consequat nisl facilisis ante tempus, at condimentum turpis fermentum.
+
+Maecenas vel feugiat turpis. Mauris et tincidunt ex, quis eleifend odio. Nunc vulputate imperdiet sollicitudin. Vestibulum varius erat leo, sed luctus turpis aliquet eget. Nullam interdum erat quis leo varius, sit amet placerat ante pellentesque. Morbi et turpis eu velit elementum mattis ac mollis diam. Vestibulum quam nunc, rhoncus quis mi in, commodo accumsan metus. Donec tristique mi in consectetur accumsan. Pellentesque purus nunc, feugiat vitae fermentum et, rhoncus ut lectus. Praesent purus lectus, aliquam ut pharetra non, tempus rhoncus nibh. Pellentesque eget nibh non massa ultricies facilisis eget sed tellus. Aenean id dignissim ex. In consequat, mi vitae volutpat efficitur, justo enim suscipit mi, eu egestas mauris est ac nibh. Sed ut purus et nunc suscipit tempor.
+
+Mauris aliquam magna justo, at ullamcorper massa fermentum vel. Phasellus nec vehicula neque, quis tincidunt sapien. Mauris vehicula eros eu lectus feugiat, id posuere libero ullamcorper. Pellentesque fermentum vel felis vitae imperdiet. Nam vitae arcu ante. Morbi posuere sollicitudin viverra. Fusce a magna eget ante commodo lobortis in quis augue.
+[^more1]: foo[^nestmore]
+
+[^nestmore]: this is nested in the more
+
+[^more2]: bar
+
+


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Improve footnote references for `entry.body` vs. `entry.more`; fixes #269 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
This adds two parameters to `entry.body`/`.more`, `footnotes_defer` and `footnotes_link`, which indicates whether footnote rendering should be deferred for later, and where a footnote's link reference should point to.

In `entry.body` it defaults to `footnotes_defer=True` and the link pointing to the URL of the entry.

In `entry.more` it defaults to `footnotes_defer=False`, and the link is empty if we're not in an absolute context, or will be the absolute link of the entry if we are in an absolute context.

This also makes the link reference and definition IDs unique on a per-entry basis, so they won't interfere with each other on an index page or the like.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
This will behave weirdly if `entry.body` and `entry.more` are used multiple times in a single template.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
See `tests/content/footnotes.md`, which behaves as expected from the index, the individual entry, and from the feed template.

## Got a site to show off?

<!-- If so, link to it here! -->
