### PR TITLE
Interpret image renditions in $-annotated attributes

### DIFF
--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -57,7 +57,10 @@ class HTMLEntry(utils.HTMLTransform):
         out_attrs = []
         for key, val in attrs:
             if (key.lower() == 'href'
+                    or key.startswith('$')
                     or (key.lower() == 'src' and tag.lower() != 'img')):
+                if key.startswith('$'):
+                    key = key[1:]
                 out_attrs.append((key, links.resolve(
                     val, self._search_path, self._config.get('absolute'))))
             else:
@@ -93,6 +96,10 @@ class HTMLEntry(utils.HTMLTransform):
             # remove that attribute and return the tag's original attributes
             LOGGER.debug("Detected already-rewritten image; %s", attrs)
             return [(key, val) for key, val in attrs if key != 'data-publ-rewritten']
+
+        if not path:
+            # this img doesn't have a src attribute, so there's something unconventional going on
+            return attrs
 
         img_path, img_args, _ = image.parse_image_spec(path)
         img = image.get_image(img_path, self._search_path)

--- a/tests/content/images/attribute renditions.md
+++ b/tests/content/images/attribute renditions.md
@@ -1,0 +1,22 @@
+Title: Attribute renditions
+Date: 2019-11-25 21:06:42-08:00
+Entry-ID: 2271
+UUID: 7724c5cb-95df-5a2a-941f-afa53a1588dd
+
+.....
+
+<img src="Landscape_1.jpg{128,128}">
+
+<a href="Landscape_2.jpg{640,640}"><img
+    id="ondemand"
+    $data-ondemand="Landscape_3.jpg{192,192}"
+    $data-ondemand-2x="Landscape_5.jpg{640,640}"
+    data-dontinterpret="rawr.jpg"></a>
+
+<script>
+window.addEventListener('load', function() {
+    var img = document.getElementById('ondemand');
+    img.src = img.getAttribute('data-ondemand');
+    img.srcset = img.getAttribute('data-ondemand') + ' 1x, ' + img.getAttribute('data-ondemand-2x') + ' 2x';
+});
+</script>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Interpret `$attributes` as image renditions (removing the `$`). Fixes #312 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
If an attribute name starts with `$`, treats it the same as `href` and also strips off the `$`. In this way we can support image renditions in custom JS libraries in `data-`attributes.

Also this fixes a subtle bug where `<img>` tags without a `src` attribute will crash, useful for supporting e.g. ondemand-loaded images.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
See `tests/content/images/attribute renditions.md`

## Got a site to show off?

<!-- If so, link to it here! -->
