### PR TITLE
Remove config.secret_key, replace with app.secret_key

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -6,6 +6,7 @@ for more information. """
 import functools
 import logging
 import re
+import uuid
 
 import arrow
 import authl.flask
@@ -83,16 +84,28 @@ class Publ(flask.Flask):
                          **kwargs)
 
         if 'AUTH_FORCE_SSL' in config.auth:
-            LOGGER.warning("The configuration key AUTH_FORCE_SSL has been \
+            LOGGER.warning("""The configuration key AUTH_FORCE_SSL has been \
 deprecated in favor of AUTH_FORCE_HTTPS. Please change your configuration \
-accordingly.")
+accordingly.
+
+This configuration value will stop being supported in Publ 0.6.
+""")
 
         auth_force_https = config.auth.get('AUTH_FORCE_HTTPS',
                                            config.auth.get('AUTH_FORCE_SSL'))
         if auth_force_https:
             self.config['SESSION_COOKIE_SECURE'] = True
 
-        self.secret_key = config.secret_key
+        if 'secret_key' in cfg:
+            LOGGER.warning("""secret_key is no longer configured in the configuration \
+dictionary; please configure it by setting the secret_key property on the Publ object \
+after initialization.
+
+This configuration value will stop being supported in Publ 0.6.
+""")
+            self.secret_key = cfg['secret_key']
+        else:
+            self.secret_key = uuid.uuid4().bytes
 
         self._regex_map = []
 

--- a/publ/config.py
+++ b/publ/config.py
@@ -3,7 +3,6 @@
 
 import sys
 import typing
-import uuid
 
 from dateutil import tz
 
@@ -41,7 +40,6 @@ markdown_extensions = (
 )
 
 # Authentication
-secret_key = str(uuid.uuid4())
 auth: typing.Dict[str, str] = {}
 user_list = 'users.cfg'
 admin_group = 'admin'

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 
 def signer():
     """ Gets the signer/validator for the tokens """
-    return itsdangerous.URLSafeTimedSerializer(config.secret_key)
+    return itsdangerous.URLSafeTimedSerializer(flask.current_app.secret_key)
 
 
 def token_endpoint():


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Gets rid of an old/confusing configuration mechanism; fixes #302 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
It turns out `config.secret_key` was only being used in one place anymore. Good thing, too!

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

Configuring it in the configuration dict now generates a warning, which will become an error in the future.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
