### PR TITLE
Universal support for markup=False

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -316,7 +316,8 @@ class Entry(caching.Memoizable):
             footnotes: typing.List[str] = []
             if is_markdown and self._body_footnotes is not False:
                 # Need to ensure that the intro footnotes are accounted for
-                self._get_markup(body, is_markdown, args=kwargs, footnote_buffer=footnotes)
+                self._get_markup(body, is_markdown, args=kwargs,
+                                 footnote_buffer=footnotes)
 
             LOGGER.debug("Intro had %d footnotes", len(footnotes))
 

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -126,4 +126,20 @@ def process(text, config, search_path):
     processor.feed(text)
     text = processor.get_data()
 
+    if not config.get('markup', True):
+        text = strip_html(text)
+
     return flask.Markup(text)
+
+class HTMLStripper(utils.HTMLTransform):
+    """ Strip all HTML tags from a document """
+
+    def handle_data(self, data):
+        self.append(data)
+
+
+def strip_html(text):
+    """ Strip all HTML formatting off of a chunk of text """
+    strip = HTMLStripper()
+    strip.feed(text)
+    return strip.get_data()

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -131,6 +131,7 @@ def process(text, config, search_path):
 
     return flask.Markup(text)
 
+
 class HTMLStripper(utils.HTMLTransform):
     """ Strip all HTML tags from a document """
 

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -223,7 +223,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
                                _mark_rewritten=True)
 
 
-def to_html(text, args, search_path, entry_id=None, footnote_buffer=None, markup=True):
+def to_html(text, args, search_path, entry_id=None, footnote_buffer=None):
     """ Convert Markdown text to HTML.
 
     footnote_buffer -- a list that will contain <li>s with the footnote items, if
@@ -238,11 +238,6 @@ def to_html(text, args, search_path, entry_id=None, footnote_buffer=None, markup
                                 args.get('markdown_extensions') or
                                 config.markdown_extensions)
     text = processor(text)
-
-    if not markup:
-        strip = HTMLStripper()
-        strip.feed(text)
-        text = strip.get_data()
 
     # convert smartquotes, if so configured
     if not args.get('no_smartquotes'):
@@ -286,12 +281,6 @@ class TitleRenderer(HtmlRenderer):
         return content
 
 
-class HTMLStripper(utils.HTMLTransform):
-    """ Strip all HTML tags from a document """
-
-    def handle_data(self, data):
-        self.append(data)
-
 
 def render_title(text, markup=True, no_smartquotes=False, markdown_extensions=None):
     """ Convert a Markdown title to HTML """
@@ -305,11 +294,10 @@ def render_title(text, markup=True, no_smartquotes=False, markdown_extensions=No
                                  or config.markdown_extensions)(text)
 
     if not markup:
-        strip = HTMLStripper()
-        strip.feed(text)
-        text = strip.get_data()
+        text = html_entry.strip_html(text)
 
     if not no_smartquotes:
         text = misaka.smartypants(text)
 
     return flask.Markup(text)
+

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -281,7 +281,6 @@ class TitleRenderer(HtmlRenderer):
         return content
 
 
-
 def render_title(text, markup=True, no_smartquotes=False, markdown_extensions=None):
     """ Convert a Markdown title to HTML """
 
@@ -300,4 +299,3 @@ def render_title(text, markup=True, no_smartquotes=False, markdown_extensions=No
         text = misaka.smartypants(text)
 
     return flask.Markup(text)
-

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -223,7 +223,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
                                _mark_rewritten=True)
 
 
-def to_html(text, args, search_path, entry_id=None, footnote_buffer=None):
+def to_html(text, args, search_path, entry_id=None, footnote_buffer=None, markup=True):
     """ Convert Markdown text to HTML.
 
     footnote_buffer -- a list that will contain <li>s with the footnote items, if
@@ -238,6 +238,11 @@ def to_html(text, args, search_path, entry_id=None, footnote_buffer=None):
                                 args.get('markdown_extensions') or
                                 config.markdown_extensions)
     text = processor(text)
+
+    if not markup:
+        strip = HTMLStripper()
+        strip.feed(text)
+        text = strip.get_data()
 
     # convert smartquotes, if so configured
     if not args.get('no_smartquotes'):

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -8,6 +8,7 @@ from pony import orm
 
 from . import model, utils
 
+
 @orm.db_session
 def set_alias(alias: str, **kwargs) -> model.PathAlias:
     """ Set a path alias.

--- a/tests/content/markdown_ext/_.cat
+++ b/tests/content/markdown_ext/_.cat
@@ -1,1 +1,3 @@
 Name: Markdown extensions
+
+This category tests Markdown extensions. This *really* needs to be done. `clearly`

--- a/tests/templates/plaintext.html
+++ b/tests/templates/plaintext.html
@@ -1,0 +1,11 @@
+{% extends 'index.html' %}
+{% block entries scoped %}
+{% for entry in content.entries %}
+<article>
+<h1><a href="{{entry.link}}">{{entry.title(markup=False)}}</a></h1>
+<p>{{entry.body(markup=False)}}</p>
+<p>{{entry.more(markup=False)}}</p>
+<p>{{entry.footnotes(markup=False)}}</p>
+</article>
+{% endfor %}
+{% endblock %}

--- a/tests/templates/sitemap.html
+++ b/tests/templates/sitemap.html
@@ -1,0 +1,8 @@
+<ul>
+{% for subcat in category.subcats recursive %}
+    <li><a href="{{subcat.link}}" title="{{subcat.description(markup=False)}}">{{ subcat.basename }}</a>: {{ subcat.name }}
+    {% if subcat.subcats %}
+    <ul>{{ loop(subcat.subcats)}}</ul>
+    {% endif %}</li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Make all markdown and HTML body processing accept `markup=False`

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Moved the HTML stripper into `html_entry` where it belongs, and made it part of the `html_entry.process` pipeline, when `markup=False`. Now it applies to anywhere that handles Markdown or HTML.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added a Markdowny description to the `markdown-ext` category, and added two templates, `sitemap` and `plaintext` to test it.

## Got a site to show off?

<!-- If so, link to it here! -->
