### PR TITLE
Simplify/improve how entry cards get parsed

### DIFF
--- a/publ/cards.py
+++ b/publ/cards.py
@@ -2,11 +2,8 @@
 """ Rendering functions for Twitter/OpenGraph cards"""
 
 import logging
-import typing
 
-import misaka
-
-from . import config, image, utils
+from . import utils
 
 LOGGER = logging.getLogger(__name__)
 
@@ -20,74 +17,6 @@ class CardData():
         self.images = []
 
 
-class MarkdownCardParser(misaka.BaseRenderer):
-    """ Customized Markdown renderer for parsing out information for a card """
-
-    def __init__(self, out, args, image_search_path):
-        super().__init__()
-
-        self._config = {**args, 'absolute': True}
-        self._image_search_path = image_search_path
-
-        self._out = out
-
-    def paragraph(self, content):
-        """ Turn the first paragraph of text into the summary text """
-        if not self._out.description:
-            self._out.description = content
-        return ' '
-
-    def image(self, raw_url, title='', alt=''):
-        ''' extract the images '''
-        max_images = self._config.get('count')
-        if max_images is not None and len(self._out.images) >= max_images:
-            # We already have enough images, so bail out
-            return ' '
-
-        image_specs = raw_url
-        if title:
-            image_specs += ' "{}"'.format(title)
-
-        alt, container_args = image.parse_alt_text(alt)
-
-        spec_list = image.get_spec_list(image_specs, container_args)
-
-        for (spec, show) in spec_list:
-            if not spec or not show:
-                continue
-
-            self._out.images.append(self._render_image(spec, alt))
-            if max_images is not None and len(self._out.images) >= max_images:
-                break
-
-        return ' '
-
-    @staticmethod
-    def link(content, link, title=''):
-        """ extract the text content out of a link """
-        # pylint: disable=unused-argument
-
-        return content
-
-    def _render_image(self, spec, alt=''):
-        """ Given an image spec, try to turn it into a card image per the configuration """
-        # pylint: disable=unused-argument
-
-        try:
-            path, image_args, _ = image.parse_image_spec(spec)
-        except Exception as err:  # pylint: disable=broad-except
-            # we tried™
-            LOGGER.exception("Got error on spec %s: %s", spec, err)
-            return None
-
-        img = image.get_image(path, self._image_search_path)
-        if img:
-            image_config = {**image_args, **self._config, 'absolute': True}
-            return img.get_rendition(1, **image_config)[0]
-
-        return None
-
-
 class HtmlCardParser(utils.HTMLTransform):
     """ Parse the first paragraph out of an HTML document """
 
@@ -96,12 +25,15 @@ class HtmlCardParser(utils.HTMLTransform):
 
         self._consume = True
         self._card = card
+        self._images = []
 
     def handle_starttag(self, tag, attrs):
         # pylint:disable=unused-argument
         if tag == 'p' and self._card.description:
             # We already got some data, so this is a malformed/old-style document
             self._consume = False
+        if tag == 'img':
+            self._card.images += [val for attr, val in attrs if attr == 'src']
 
     def handle_endtag(self, tag):
         if tag == 'p':
@@ -114,18 +46,9 @@ class HtmlCardParser(utils.HTMLTransform):
             self._card.description += data
 
 
-def extract_card(text: str,
-                 is_markdown: bool,
-                 args: typing.Dict[str, typing.Any],
-                 image_search_path: typing.Tuple[str]) -> CardData:
-    """ Extract card data based on the provided texts. """
+def extract_card(html_text: str) -> CardData:
+    """ Extract card data based on the provided HTML. """
     card = CardData()
-    if is_markdown:
-        misaka.Markdown(MarkdownCardParser(card, args, image_search_path),
-                        extensions=args.get('markdown_extensions')
-                        or config.markdown_extensions
-                        )(text)
-    else:
-        HtmlCardParser(card).feed(text)
+    HtmlCardParser(card).feed(html_text)
 
     return card

--- a/publ/cards.py
+++ b/publ/cards.py
@@ -16,6 +16,8 @@ class CardData():
         self.description = None
         self.images = []
 
+    def commit(self):
+        self.description = self.description.strip()
 
 class HtmlCardParser(utils.HTMLTransform):
     """ Parse the first paragraph out of an HTML document """
@@ -50,5 +52,6 @@ def extract_card(html_text: str) -> CardData:
     """ Extract card data based on the provided HTML. """
     card = CardData()
     HtmlCardParser(card).feed(html_text)
+    card.commit()
 
     return card

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -388,7 +388,8 @@ class Entry(caching.Memoizable):
                                      is_markdown,
                                      args={'count': 1,
                                            **kwargs,
-                                           "max_scale": 1})
+                                           "max_scale": 1},
+                                     footnote_buffer=False)
         return cards.extract_card(html_text)
 
     @cached_property
@@ -419,7 +420,7 @@ class Entry(caching.Memoizable):
         return self._record.is_authorized(user.get_active())
 
     def _get_markup(self, text, is_markdown, args,
-                    footnote_buffer: typing.Optional[typing.List[str]] = None) -> str:
+                    footnote_buffer: markdown.FootnoteBuffer = None) -> str:
         """ get the rendered markup for an entry
 
             is_markdown -- whether the entry is formatted as Markdown

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -370,18 +370,26 @@ class Entry(caching.Memoizable):
             tags = og_tag('og:title', self.title(markup=False))
             tags += og_tag('og:url', self.link(absolute=True))
 
-            body, more, is_markdown = self._entry_content
-
-            card = cards.extract_card(body or more, is_markdown, kwargs, self.search_path)
-            for image in card.images:
+            card = self._get_card_data(kwargs)
+            for image in card.images[:kwargs.get('count', 1)]:
                 tags += og_tag('og:image', image)
-            if card.description:
-                tags += og_tag('og:description',
-                               self.get('Summary', card.description))
+            description = self.get('Summary', card.description)
+            if description:
+                tags += og_tag('og:description', description)
 
             return flask.Markup(tags)
 
         return CallableProxy(_get_card)
+
+    def _get_card_data(self, kwargs) -> cards.CardData:
+        body, more, is_markdown = self._entry_content
+
+        html_text = self._get_markup(body or more,
+                                     is_markdown,
+                                     args={'count': 1,
+                                           **kwargs,
+                                           "max_scale": 1})
+        return cards.extract_card(html_text)
 
     @cached_property
     def summary(self) -> typing.Callable[..., str]:
@@ -393,12 +401,7 @@ class Entry(caching.Memoizable):
             if self.get('Summary'):
                 return self.get('Summary')
 
-            body, more, is_markdown = self._entry_content
-
-            card = cards.extract_card(body or more,
-                                      is_markdown, kwargs,
-                                      self.search_path)
-
+            card = self._get_card_data(kwargs)
             return flask.Markup((card.description or '').strip())
 
         return CallableProxy(_get_summary)

--- a/tests/content/cards/markdown with footnote.md
+++ b/tests/content/cards/markdown with footnote.md
@@ -1,0 +1,8 @@
+Title: Markdown entry with footnote
+Date: 2020-01-03 15:05:53-08:00
+Entry-ID: 1503
+UUID: 84bb8bce-5676-54f0-8b20-d5348a383464
+
+This is a footnote[^footnote]. It should not appear in the summary.
+
+[^footnote]: Technically *this* is the footnote.

--- a/tests/content/markdown-titles/leading number.md
+++ b/tests/content/markdown-titles/leading number.md
@@ -1,0 +1,6 @@
+Title: 1. The loneliest number.
+Date: 2019-12-31 00:51:51-08:00
+Entry-ID: 2374
+UUID: 8ac9b013-4dae-52c6-a378-2436e2415cc2
+
+`1. The loneliest number.`

--- a/tests/templates/cards/entry.txt
+++ b/tests/templates/cards/entry.txt
@@ -13,3 +13,7 @@
 ==More text==
 
 {{entry.more or '(no more)'}}
+
+==Footnote text==
+
+{{entry.footnotes or '(no footnotes)'}}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Entry cards are now extracted from the generated HTML instead of using a custom Markdown parser. Fixes #223. Fixes #325. 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Previously, as a short-sighted optimization, Markdown entries went through a purpose-specific Markdown parser for extracting cards, before going through an HTML paragraph extractor anyway. This parser was unable to handle footnotes, and probably had a few other gotchas. Instead of simply adding footnote processing, it seemed easier to just run it through the normal entry formatting process and then extract the summary and images from the generated HTML.

This also makes it so that HTML entries will get images in their card as well. So, this improves lots of things.

As a side-effect, cards will now also generate high-DPI renditions for images, which is unnecessary and a (very) slight waste of resources; fixing #326 will fix this problem as well.

The `count` argument to `entry.card` will also now limit the total number of images that are included in the card (with a default of 1); however, renditions will still be generated for all images in the intro. This is no worse than how things were before, though.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added footnote tests to the cards tests; verified that the previously-failing tests no longer fail (i.e. the HTML entries now get correct summary generation).

## Got a site to show off?

<!-- If so, link to it here! -->
