### PR TITLE
Refactor LocalImage rendering mechanism

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,10 +25,10 @@
         },
         "arrow": {
             "hashes": [
-                "sha256:01a16d8a93eddf86a29237f32ae36b29c27f047e79312eb4df5d55fd5a2b3183",
-                "sha256:e1a318a4c0b787833ae46302c02488b6eeef413c6a13324b3261ad320f21ec1e"
+                "sha256:5390e464e2c5f76971b60ffa7ee29c598c7501a294bc9f5e6dadcb251a5d027b",
+                "sha256:70729bcc831da496ca3cb4b7e89472c8e2d27d398908155e0796179f6d2d41ee"
             ],
-            "version": "==0.15.4"
+            "version": "==0.15.5"
         },
         "atomicwrites": {
             "hashes": [
@@ -206,38 +206,30 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:047d9473cf68af50ac85f8ee5d5f21a60f849bc17d348da7fc85711287a75031",
-                "sha256:0f66dc6c8a3cc319561a633b6aa82c44107f12594643efa37210d8c924fc1c71",
-                "sha256:12c9169c4e8fe0a7329e8658c7e488001f6b4c8e88740e76292c2b857af2e94c",
-                "sha256:248cffc168896982f125f5c13e9317c059f74fffdb4152893339f3be62a01340",
-                "sha256:27faf0552bf8c260a5cee21a76e031acaea68babb64daf7e8f2e2540745082aa",
-                "sha256:285edafad9bc60d96978ed24d77cdc0b91dace88e5da8c548ba5937c425bca8b",
-                "sha256:384b12c9aa8ef95558abdcb50aada56d74bc7cc131dd62d28c2d0e4d3aadd573",
-                "sha256:38950b3a707f6cef09cd3cbb142474357ad1a985ceb44d921bdf7b4647b3e13e",
-                "sha256:4aad1b88933fd6dc2846552b89ad0c74ddbba2f0884e2c162aa368374bf5abab",
-                "sha256:4ac6148008c169603070c092e81f88738f1a0c511e07bd2bb0f9ef542d375da9",
-                "sha256:4deb1d2a45861ae6f0b12ea0a786a03d19d29edcc7e05775b85ec2877cb54c5e",
-                "sha256:59aa2c124df72cc75ed72c8d6005c442d4685691a30c55321e00ed915ad1a291",
-                "sha256:5a47d2123a9ec86660fe0e8d0ebf0aa6bc6a17edc63f338b73ea20ba11713f12",
-                "sha256:5cc901c2ab9409b4b7ac7b5bcc3e86ac14548627062463da0af3b6b7c555a871",
-                "sha256:6c1db03e8dff7b9f955a0fb9907eb9ca5da75b5ce056c0c93d33100a35050281",
-                "sha256:7ce80c0a65a6ea90ef9c1f63c8593fcd2929448613fc8da0adf3e6bfad669d08",
-                "sha256:809c19241c14433c5d6135e1b6c72da4e3b56d5c865ad5736ab99af8896b8f41",
-                "sha256:83792cb4e0b5af480588601467c0764242b9a483caea71ef12d22a0d0d6bdce2",
-                "sha256:846fa202bd7ee0f6215c897a1d33238ef071b50766339186687bd9b7a6d26ac5",
-                "sha256:9f5529fc02009f96ba95bea48870173426879dc19eec49ca8e08cd63ecd82ddb",
-                "sha256:a423c2ea001c6265ed28700df056f75e26215fd28c001e93ef4380b0f05f9547",
-                "sha256:ac4428094b42907aba5879c7c000d01c8278d451a3b7cccd2103e21f6397ea75",
-                "sha256:b1ae48d87f10d1384e5beecd169c77502fcc04a2c00a4c02b85f0a94b419e5f9",
-                "sha256:bf4e972a88f8841d8fdc6db1a75e0f8d763e66e3754b03006cbc3854d89f1cb1",
-                "sha256:c6414f6aad598364aaf81068cabb077894eb88fed99c6a65e6e8217bab62ae7a",
-                "sha256:c710fcb7ee32f67baf25aa9ffede4795fd5d93b163ce95fdc724383e38c9df96",
-                "sha256:c7be4b8a09852291c3c48d3c25d1b876d2494a0a674980089ac9d5e0d78bd132",
-                "sha256:c9e5ffb910b14f090ac9c38599063e354887a5f6d7e6d26795e916b4514f2c1a",
-                "sha256:e0697b826da6c2472bb6488db4c0a7fa8af0d52fa08833ceb3681358914b14e5",
-                "sha256:e9a3edd5f714229d41057d56ac0f39ad9bdba6767e8c888c951869f0bdd129b0"
+                "sha256:0a628977ac2e01ca96aaae247ec2bd38e729631ddf2221b4b715446fd45505be",
+                "sha256:4d9ed9a64095e031435af120d3c910148067087541131e82b3e8db302f4c8946",
+                "sha256:54ebae163e8412aff0b9df1e88adab65788f5f5b58e625dc5c7f51eaf14a6837",
+                "sha256:5bfef0b1cdde9f33881c913af14e43db69815c7e8df429ceda4c70a5e529210f",
+                "sha256:5f3546ceb08089cedb9e8ff7e3f6a7042bb5b37c2a95d392fb027c3e53a2da00",
+                "sha256:5f7ae9126d16194f114435ebb79cc536b5682002a4fa57fa7bb2cbcde65f2f4d",
+                "sha256:62a889aeb0a79e50ecf5af272e9e3c164148f4bd9636cc6bcfa182a52c8b0533",
+                "sha256:7406f5a9b2fd966e79e6abdaf700585a4522e98d6559ce37fc52e5c955fade0a",
+                "sha256:8453f914f4e5a3d828281a6628cf517832abfa13ff50679a4848926dac7c0358",
+                "sha256:87269cc6ce1e3dee11f23fa515e4249ae678dbbe2704598a51cee76c52e19cda",
+                "sha256:875358310ed7abd5320f21dd97351d62de4929b0426cdb1eaa904b64ac36b435",
+                "sha256:8ac6ce7ff3892e5deaab7abaec763538ffd011f74dc1801d93d3c5fc541feee2",
+                "sha256:91b710e3353aea6fc758cdb7136d9bbdcb26b53cefe43e2cba953ac3ee1d3313",
+                "sha256:9d2ba4ed13af381233e2d810ff3bab84ef9f18430a9b336ab69eaf3cd24299ff",
+                "sha256:a62ec5e13e227399be73303ff301f2865bf68657d15ea50b038d25fc41097317",
+                "sha256:ab76e5580b0ed647a8d8d2d2daee170e8e9f8aad225ede314f684e297e3643c2",
+                "sha256:bf4003aa538af3f4205c5fac56eacaa67a6dd81e454ffd9e9f055fff9f1bc614",
+                "sha256:bf598d2e37cf8edb1a2f26ed3fb255191f5232badea4003c16301cb94ac5bdd0",
+                "sha256:c18f70dc27cc5d236f10e7834236aff60aadc71346a5bc1f4f83a4b3abee6386",
+                "sha256:c5ed816632204a2fc9486d784d8e0d0ae754347aba99c811458d69fcdfd2a2f9",
+                "sha256:dc058b7833184970d1248135b8b0ab702e6daa833be14035179f2acb78ff5636",
+                "sha256:ff3797f2f16bf9d17d53257612da84dd0758db33935777149b3334c01ff68865"
             ],
-            "version": "==6.2.1"
+            "version": "==7.0.0"
         },
         "pony": {
             "hashes": [
@@ -609,10 +601,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:166a82cdea964ae45528e0cc89436255ff2be73dc848bdf239f13c501cae5dc7",
-                "sha256:9036904496bd2afacf836a6f206c5a766ce11d3e9319d54a4e794c0f34b111dc"
+                "sha256:4789ccbb6fc122b5a6a85d512e4e41fc5acad77216533a6f2b8ce51e0f265c23",
+                "sha256:efab950cf7cc1e4d8ee50b2bb9c8e4a89f8307b49e0b2c9cfef3ec4ca26655eb"
             ],
-            "version": "==4.41.0"
+            "version": "==4.41.1"
         },
         "twine": {
             "hashes": [

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -112,7 +112,12 @@ class HTMLEntry(utils.HTMLTransform):
             img_attrs = img.get_img_attrs(**config)
         except FileNotFoundError as error:
             img_attrs = {
-                'data-publ-error': 'file not found: {}'.format(error.filename)
+                'data-publ-error': 'File Not Found: {}'.format(error.filename)
+            }
+        except Exception as error:  # pylint:disable=broad-except
+            LOGGER.exception("Got exception: %s", error)
+            img_attrs = {
+                'data-publ-error': 'Error: {}'.format(str(error))
             }
 
         # return the original attr list with the computed overrides in place

--- a/publ/image/local.py
+++ b/publ/image/local.py
@@ -278,12 +278,6 @@ class LocalImage(Image):
 
         return image
 
-    @staticmethod
-    def _crop_to_box(crop):
-        # pylint:disable=invalid-name
-        xx, yy, ww, hh = crop
-        return (xx, yy, xx + ww, yy + hh)
-
     def get_rendition_size(self, spec, output_scale, crop) -> SizeSpecType:
         """
         Wrapper to determine the overall rendition size and cropping box

--- a/publ/image/local.py
+++ b/publ/image/local.py
@@ -224,7 +224,6 @@ class LocalImage(Image):
         return size, None
 
     def _render(self, path, operations: typing.List[typing.Callable], out_args):
-        # pylint:disable=too-many-arguments
         image = self._image
 
         with self._lock:

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -216,24 +216,23 @@ class HtmlRenderer(misaka.HtmlRenderer):
             path, image_args, title = image.parse_image_spec(spec)
         except Exception as err:  # pylint: disable=broad-except
             LOGGER.exception("Got error on spec %s: %s", spec, err)
-            return ('<span class="error">Couldn\'t parse image spec: ' +
-                    '<code>{}</code> {}</span>'.format(flask.escape(spec),
-                                                       flask.escape(str(err))))
+            return flask.Markup('<span class="error">Couldn\'t parse image spec: ' +
+                                '<code>{}</code> {}</span>'.format(flask.escape(spec),
+                                                                   flask.escape(str(err))))
 
         composite_args = {**container_args, **image_args}
 
         try:
             img = image.get_image(path, self._search_path)
+            return img.get_img_tag(title,
+                                   alt_text,
+                                   **composite_args,
+                                   _show_thumbnail=show,
+                                   _mark_rewritten=True)
         except Exception as err:  # pylint: disable=broad-except
             LOGGER.exception("Got error on image %s: %s", path, err)
-            return ('<span class="error">Error loading image {}: {}</span>'.format(
+            return flask.Markup('<span class="error">Error loading image {}: {}</span>'.format(
                 flask.escape(spec), flask.escape(str(err))))
-
-        return img.get_img_tag(title,
-                               alt_text,
-                               **composite_args,
-                               _show_thumbnail=show,
-                               _mark_rewritten=True)
 
 
 def to_html(text, args, search_path, entry_id=None, footnote_buffer=None):

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -399,3 +399,10 @@ def stash(key: str) -> typing.Callable:
             return val
         return wrapped_func
     return decorator
+
+
+def parse_tuple_string(argument, type_func=int) -> typing.Tuple:
+    """ Return a tuple from parsing 'a,b,c,d' -> (a,b,c,d) """
+    if isinstance(argument, str):
+        return tuple(type_func(p.strip()) for p in argument.split(','))
+    return argument

--- a/tests/content/images/html renditions.html
+++ b/tests/content/images/html renditions.html
@@ -1,0 +1,12 @@
+Title: HTML renditions
+Date: 2020-01-04 00:42:19-08:00
+Entry-ID: 2174
+UUID: b95a3bf1-a110-5c33-b41a-78a4e0c57bfb
+
+tests of how parse failures affect HTML entries
+
+.....
+
+<img src="not found.jpg" title="file not found">
+
+<img src="rawr.jpg{scale_filter='xyzzy'}" width="128" title="invalid scale filter">

--- a/tests/content/images/image renditions.md
+++ b/tests/content/images/image renditions.md
@@ -150,7 +150,7 @@ converted to jpeg, red background using a tuple:
 
 converted to jpeg, white background using hex code:
 
-![](notsmiley.png{format="jpg",background='#fff'}) `![](notsmiley.png{format="jpg",background='#fff'})`
+![](notsmiley.png{format="jpg",background='#ccc'}) `![](notsmiley.png{format="jpg",background='#ccc'})`
 
 
 converted to jpeg, cyan background, multiple qualities on the spectrum:
@@ -168,6 +168,30 @@ notsmiley.png{quality=1} "quality 1"
 | notsmiley.png{quality=50} "quality 50"
 | notsmiley.png{quality=99} "quality 99"
 | notsmiley.png "quality default"
+)
+```
+
+## Quantization
+
+![{256,256}](Landscape_4.jpg "default"
+| Landscape_4.jpg{format='png'} "png24"
+| Landscape_4.jpg{format='png',quantize=0} "png8 0"
+| Landscape_4.jpg{format='png',quantize=128} "png8 128"
+| Landscape_4.jpg{format='png',quantize=32} "png8 32"
+| Landscape_4.jpg{format='png',quantize=4} "png8 4"
+| Landscape_4.jpg{format='png',quantize=2} "png8 2"
+| Landscape_4.jpg{format='png',quantize=256} "png8 256"
+| Landscape_4.jpg{format='gif'} "gif8"
+)
+
+```markdown
+![{256,256}](Landscape_4.jpg{format='png'} "png24"
+| Landscape_4.jpg{format='png',quantize=0} "png8 0"
+| Landscape_4.jpg{format='png',quantize=128} "png8 128"
+| Landscape_4.jpg{format='png',quantize=32} "png8 32"
+| Landscape_4.jpg{format='png',quantize=4} "png8 4"
+| Landscape_4.jpg{format='png',quantize=2} "png8 2"
+| Landscape_4.jpg{format='gif'} "gif8"
 )
 ```
 

--- a/tests/content/images/image renditions.md
+++ b/tests/content/images/image renditions.md
@@ -195,6 +195,30 @@ notsmiley.png{quality=1} "quality 1"
 )
 ```
 
+## Scale algorithms
+
+![{512,512,format='png'}](Landscape_1.jpg "default"
+| Landscape_1.jpg{scale_filter='nearest'} "nearest"
+| Landscape_1.jpg{scale_filter='box'} "box"
+| Landscape_1.jpg{scale_filter='bilinear'} "bilinear"
+| Landscape_1.jpg{scale_filter='hamming'} "hamming"
+| Landscape_1.jpg{scale_filter='bicubic'} "bicubic"
+| Landscape_1.jpg{scale_filter='lanczos'} "lanczos"
+| Landscape_1.jpg{scale_filter='xyzzy'} "xyzzy"
+)
+
+```
+![{512,512,format='png'}](Landscape_1.jpg "default"
+| Landscape_1.jpg{scale_filter='nearest'} "nearest"
+| Landscape_1.jpg{scale_filter='box'} "box"
+| Landscape_1.jpg{scale_filter='bilinear'} "bilinear"
+| Landscape_1.jpg{scale_filter='hamming'} "hamming"
+| Landscape_1.jpg{scale_filter='bicubic'} "bicubic"
+| Landscape_1.jpg{scale_filter='lanczos'} "lanczos"
+| Landscape_1.jpg{scale_filter='xyzzy'} "xyzzy"
+)
+```
+
 ## Broken/parse failures
 
 * `![broken image](missingfile.jpg)`

--- a/tests/content/images/shaped images.md
+++ b/tests/content/images/shaped images.md
@@ -7,15 +7,19 @@ Tests of shaped image floats
 
 .....
 
+<style>
+    p { text-align: justify; }
+</style>
+
 ![{shape=True,style="float:left",width=200,height=200}](notsmiley.png)
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ornare nec elit sit amet suscipit. Aenean pellentesque ut dui at tincidunt. Sed placerat semper risus nec volutpat. Sed et feugiat ligula. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Pellentesque imperdiet gravida lectus id viverra. Pellentesque lacinia eros at imperdiet tempor. Duis at aliquet risus, id accumsan ex. Nulla ut magna ante. Vestibulum tellus turpis, consequat sed magna nec, bibendum congue mauris. Aenean dignissim quis neque ornare tempor.
 
-![{shape=True,style="float:right",width=250,height=250}](//publ.beesbuzz.biz/static/images/funky-shape.png{height=250})
+![{shape='@images/funky-shape.png',style="float:right",width=128,height=128}](//publ.beesbuzz.biz/static/images/funky-shape.png)
 
 Morbi elementum nunc vitae elit rhoncus, pellentesque egestas justo pulvinar. Donec pharetra leo sed neque fermentum tincidunt. Nulla facilisi. Nulla facilisi. Quisque vehicula mi sed dui commodo, nec bibendum augue aliquam. Praesent vitae dui eu libero hendrerit interdum at vitae neque. Aenean faucibus nunc porttitor, suscipit dui at, commodo mauris. Proin faucibus porttitor pulvinar. Vestibulum bibendum eu augue vitae ultricies. Sed maximus, leo ac viverra efficitur, orci neque venenatis enim, eu commodo massa elit in odio.
 
-![{shape='@images/funky-shape.png',style="float:left"}](@images/funky-shape.png)
+![{shape=True,style="float:left"}](@images/funky-shape.png)
 
 Etiam eu lacus ligula. Maecenas condimentum ligula ut mauris congue elementum id euismod lectus. Phasellus interdum eget enim et tincidunt. Phasellus finibus lectus nec nibh elementum, et fermentum ligula lobortis. Sed ultricies lacinia magna. Sed eu luctus leo, eget commodo enim. Duis ante turpis, commodo auctor viverra sit amet, mollis eget magna. Aenean lacinia nisl egestas, commodo mauris ac, blandit augue. Mauris non ultrices tellus, sed luctus nulla. Donec scelerisque, velit id porta commodo, erat lacus lacinia nisl, eget tincidunt nulla justo at libero. Praesent diam lectus, luctus a ultricies sit amet, sollicitudin eget arcu. Aliquam ligula urna, pellentesque vel porta vitae, pretium ac ipsum.
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Refactors `LocalImage.get_rendition`; fixes #173 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Rather than having separate pipelines for determining the filename and the rendering of the file, this gloms them together in a more extensible way that also doesn't require adding increasingly many arguments for every operation.

This also fixes a bug where different quantization levels for PNGs and GIFs wouldn't have rendered out separate images, and also improves the quality and file size for flattened images by pre-composing the background before crop-scaling.

This also adds the `scale_filter` image rendition argument, documented in https://github.com/PlaidWeb/publ-site/commit/54de24a861a1258713f18e50b99ce36401cb6d61

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added quantization tests, and verified all of the existing image tests still work correctly.

## Got a site to show off?

<!-- If so, link to it here! -->
