### PR TITLE
Implement heading anchors and tables of content

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -307,6 +307,8 @@ class Entry(caching.Memoizable):
         body, _, is_markdown = self._entry_content
 
         def _body(**kwargs) -> str:
+            LOGGER.debug("Rendering body; args=%s", kwargs)
+
             footnotes: typing.Optional[typing.List[str]] = [
             ] if self._body_footnote is None else None
             tocs: typing.Optional[markdown.TocBuffer] = [] if self._body_toc is None else None
@@ -333,11 +335,14 @@ class Entry(caching.Memoizable):
         body, more, is_markdown = self._entry_content
 
         def _more(**kwargs) -> str:
+            LOGGER.debug("Rendering more; kwargs=%s", kwargs)
+
+            footnotes: typing.Optional[typing.List[str]] = []
+            tocs: typing.Optional[markdown.TocBuffer] = []
+
             if is_markdown and (self._body_footnotes is None or self._body_toc is None):
                 # Need to ensure that the intro footnotes/TOC are accounted for
                 LOGGER.debug("scanning intro footnotes/tocs")
-                footnotes: typing.Optional[typing.List[str]] = []
-                tocs: typing.Optional[markdown.TocBuffer] = []
                 self._get_markup(body, is_markdown, args=kwargs,
                                  footnote_buffer=footnotes,
                                  toc_buffer=tocs)
@@ -346,19 +351,11 @@ class Entry(caching.Memoizable):
 
             LOGGER.debug("intro footnotes=%s tocs=%s", self._body_footnotes, self._body_toc)
 
-            if self._more_footnotes is None:
-                # pre-fill the buffer with empty entries so the counts are correct
-                footnotes = [''] * self._body_footnotes if self._body_footnotes else []
-            else:
-                # no need to scan
-                footnotes = None
+            # pre-fill the buffer with empty entries so the counts are correct
+            footnotes = [''] * self._body_footnotes if self._body_footnotes else []
 
-            if self._more_toc is None:
-                # pre-fill the buffer with empty entries so the counts are correct
-                tocs = [(0, '')] * self._body_toc if self._body_toc else []
-            else:
-                # no need to scan
-                tocs = None
+            # pre-fill the buffer with empty entries so the counts are correct
+            tocs = [(0, '')] * self._body_toc if self._body_toc else []
 
             more_text = self._get_markup(more, is_markdown,
                                          footnote_buffer=footnotes,
@@ -384,7 +381,7 @@ class Entry(caching.Memoizable):
         body, more, is_markdown = self._entry_content
 
         def _footnotes(**kwargs) -> str:
-            LOGGER.debug("rendering footnotes")
+            LOGGER.debug("rendering footnotes; args=%s", kwargs)
             return self._get_footnotes(body, more, kwargs)
 
         LOGGER.debug("is_markdown %s  body_footnotes %s  more_footnotes %s",
@@ -409,7 +406,7 @@ class Entry(caching.Memoizable):
         body, more, is_markdown = self._entry_content
 
         def _toc(max_depth=None, **kwargs) -> str:
-            LOGGER.debug("rendering table of contents")
+            LOGGER.debug("rendering table of contents; args=%s", kwargs)
             return self._get_toc(body, more, max_depth, kwargs)
 
         if is_markdown:
@@ -429,6 +426,8 @@ class Entry(caching.Memoizable):
 
         def _get_card(**kwargs) -> str:
             """ Render out the tags for a Twitter/OpenGraph card for this entry. """
+
+            LOGGER.debug("rendering card; args=%s", kwargs)
 
             def og_tag(key, val) -> str:
                 """ produce an OpenGraph tag with the given key and value """

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -44,11 +44,15 @@ class Entry(caching.Memoizable):
 
         LOGGER.debug('init entry %d', record.id)
         self._record = record   # index record
-        self._body_footnotes: typing.Optional[int] = None  # do we know if there's intro footnotes?
-        # do we know if there's moretext footnotes?
+
+        # How many footnotes and TOC entries are in the body?
+        self._body_footnotes: typing.Optional[int] = None
         self._more_footnotes: typing.Optional[int] = None
-        self._body_toc: typing.Optional[int] = None  # do we know if there's intro headings?
-        self._more_toc: typing.Optional[int] = None  # do we know if there's moretext headings?
+
+        # How many footnotes and TOC entries are in the more-text?
+        self._body_toc: typing.Optional[int] = None
+        self._more_toc: typing.Optional[int] = None
+
         self._fingerprint = model.FileFingerprint.get(file_path=record.file_path)
         LOGGER.debug('loaded entry %d, fingerprint=%s', record.id, self._fingerprint.fingerprint)
 

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -121,8 +121,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
         atag = utils.make_tag('a', {
             'href': urllib.parse.urljoin(self._config.get('toc_link', ''),
                                          '#' + hid),
-            'class': self._config.get('heading_toclink_class', False),
-            **self._config.get('heading_toclink_config', {})
+            'class': self._config.get('heading_link_class', False),
+            **self._config.get('heading_link_config', {})
         })
 
         if self._toc_buffer is not None:
@@ -133,9 +133,9 @@ class HtmlRenderer(misaka.HtmlRenderer):
                      atag=atag,
                      content=html_entry.strip_html(content, allowed=TOC_ALLOWED_TAGS))))
 
-        if 'heading_toclink_class' in self._config or 'heading_template' in self._config:
-            content = self._config.get('heading_template', '{toc_link}</a>{text}').format(
-                toc_link=atag,
+        if 'heading_link_class' in self._config or 'heading_template' in self._config:
+            content = self._config.get('heading_template', '{link}</a>{text}').format(
+                link=atag,
                 text=content)
 
         return '{htag_open}{content}</{htag}>'.format(

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -119,7 +119,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
                               len(self._toc_buffer) + 1)
 
         atag = utils.make_tag('a', {
-            'href': '#' + hid,
+            'href': urllib.parse.urljoin(self._config.get('toc_link', ''),
+                                         '#' + hid),
             'class': self._config.get('toc_link_class', False),
             **self._config.get('toc_link_config', {})
         })

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -279,8 +279,8 @@ def to_html(text, args, search_path,
 
     """
 
-    footnotes:typing.List[str] = footnote_buffer if footnote_buffer is not None else []
-    tocs:TocBuffer = toc_buffer if toc_buffer is not None else []
+    footnotes: typing.List[str] = footnote_buffer if footnote_buffer is not None else []
+    tocs: TocBuffer = toc_buffer if toc_buffer is not None else []
 
     # first process as Markdown
     renderer = HtmlRenderer(args,
@@ -306,7 +306,7 @@ def to_html(text, args, search_path,
     # now filter through html_entry to rewrite local src/href links
     text = html_entry.process(text, args, search_path)
     footnotes[:] = [html_entry.process(text, args, search_path)
-                          for text in footnotes]
+                    for text in footnotes]
 
     return flask.Markup(text)
 

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -121,8 +121,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
         atag = utils.make_tag('a', {
             'href': urllib.parse.urljoin(self._config.get('toc_link', ''),
                                          '#' + hid),
-            'class': self._config.get('toc_link_class', False),
-            **self._config.get('toc_link_config', {})
+            'class': self._config.get('heading_toclink_class', False),
+            **self._config.get('heading_toclink_config', {})
         })
 
         if self._toc_buffer is not None:
@@ -133,10 +133,10 @@ class HtmlRenderer(misaka.HtmlRenderer):
                      atag=atag,
                      content=html_entry.strip_html(content, allowed=TOC_ALLOWED_TAGS))))
 
-        if 'toc_link_class' in self._config or 'toc_link_template' in self._config:
-            content = self._config.get('toc_link_template', '{atag}{content}</a>').format(
-                atag=atag,
-                content=content)
+        if 'heading_toclink_class' in self._config or 'heading_template' in self._config:
+            content = self._config.get('heading_template', '{toc_link}</a>{text}').format(
+                toc_link=atag,
+                text=content)
 
         return '{htag_open}{content}</{htag}>'.format(
             htag_open=utils.make_tag(htag, {'id': hid}),

--- a/tests/content/toc/postprocessing.md
+++ b/tests/content/toc/postprocessing.md
@@ -1,0 +1,61 @@
+Title: TOC with postprocessing
+Date: 2020-02-03 23:06:08-08:00
+Entry-ID: 1886
+UUID: cc74548e-f159-55f2-a052-00fd680e74c9
+
+This TOC needs postprocessing.
+
+.....
+
+## Smartypants stuff
+
+### A "smartquotes" heading
+
+This heading has "smartquotes."
+
+### Em-dashes -- not just for fun --- perhaps
+
+This heading has an en-dash -- and maybe an em-dash --- yes
+
+### Fractions like 1/2 and 1/4 are silly
+
+They are.
+
+## Image stuff
+
+### <img src="../images/rawr.jpg"> Inline rawr?
+
+Nope
+
+### ![](../images/rawr.jpg) Markdown rawr?
+
+Nope
+
+### Markdown [rawr link](../images/rawr.jpg)
+
+Nope
+
+### HTML <a href="../images/rawr.jpg">rawr link</a>
+
+Nope
+
+## Formatting
+
+### *Emphasis* and **strong**
+
+Should be allowed.
+
+### <em>em</em> <b>b</b> <sup>sup</sup> <sub>sub</sub> <strong>strong</strong> <i>i</i>
+
+Should be allowed.
+
+### Superscripts^2
+
+I'll allow it.
+
+### Footnotes[^notes]
+
+[^notes]: This makes no sense in the ToC
+
+Makes no sense in the ToC, but it's hard to filter that out.
+

--- a/tests/content/toc/screwy.md
+++ b/tests/content/toc/screwy.md
@@ -1,0 +1,32 @@
+Title: Has a screwy table of contents
+Date: 2020-02-03 19:39:04-08:00
+UUID: 79601818-e808-5cdb-b2de-298ab4278a67
+Entry-ID: 612
+
+This entry has a table of contents.
+
+# Why a table of contents?
+
+Because it's neat.
+
+.....
+
+## What happens if the subsection is in the body text?
+
+Good question!
+
+# Level 1
+
+## Level 2
+
+### Level 3
+
+## Level 2
+
+##### Level 5
+
+### Level 3
+
+## This is a screwy TOC
+
+# Yep

--- a/tests/content/toc/screwy.md
+++ b/tests/content/toc/screwy.md
@@ -5,7 +5,7 @@ Entry-ID: 612
 
 This entry has a table of contents.
 
-# Why a table of contents?
+## Why a table of contents?
 
 Because it's neat.
 

--- a/tests/content/toc/toc.md
+++ b/tests/content/toc/toc.md
@@ -1,0 +1,28 @@
+Title: Well-formed TOC
+Date: 2020-02-03 20:47:16-08:00
+Entry-ID: 2467
+UUID: 79601818-e808-5cdb-b2de-298ab4278a67
+
+## Lead Intro
+
+### Subsection 1
+
+### Subsection 2
+
+.....
+
+## Body Intro
+
+### Subsection 1
+
+#### Subsubsection 1
+
+### Subsection 2
+
+#### Subsubsection 1
+
+#### Subsubsection 2
+
+## Body conclusion
+
+Tables of contents are hard.

--- a/tests/templates/_entry.html
+++ b/tests/templates/_entry.html
@@ -56,13 +56,13 @@
             <div class="source_file">Source file: <tt>{{entry.file_path}}</tt></div>
             {% block entrycontent scoped %}
             {% if entry.summary %}
-                <div class="p-summary">{{entry.summary}}</div>
+                <div class="p-summary">{{entry.summary(toc_link_class='toc_link')}}</div>
             {% else %}
                 <!-- summary is empty -->
             {% endif %}
 
             <div class="entry e-content">
-            {{entry.body(footnotes_class='gronk')}}
+            {{entry.body(footnotes_class='gronk',toc_link_class='toc_link')}}
             {% if entry.more %}
             <div id="more">
                 {{entry.more(footnotes_class='plonk')}}

--- a/tests/templates/_entry.html
+++ b/tests/templates/_entry.html
@@ -24,8 +24,8 @@
     {% endblock %}
 
     {% block sidebar %}
-    <div id="nav" class="sidebar">
-        {% block navigation %}
+    <nav id="nav" class="sidebar">
+        {% block navigation scoped %}
         <h2>Navigation</h2>
         <ul>
             <li class="cat-back"><a href="{{category.link}}" title="{{category.name(markup=False)}}">Back to {{category.name or "main site"}}</a></li>
@@ -36,7 +36,7 @@
             {% endif %}
         </ul>
         {% endblock %}
-    </div>
+    </nav>
     {% endblock %}
 
     <div id="content">
@@ -54,6 +54,7 @@
             <div class="posted">Last updated: <time class="dt-posted" datetime="{{entry.date.isoformat()}}">{{entry.last_modified.format('YYYY-MM-DD h:mm A')}} ({{entry.last_modified.humanize()}})</time>
             </div>
             <div class="source_file">Source file: <tt>{{entry.file_path}}</tt></div>
+            {% block entrycontent scoped %}
             {% if entry.summary %}
                 <div class="p-summary">{{entry.summary}}</div>
             {% else %}
@@ -76,6 +77,7 @@
             </div>
             {% endif %}
             </div>
+            {% endblock %}
             {% endblock %}
             </article>
             {% endif %}

--- a/tests/templates/toc/entry.html
+++ b/tests/templates/toc/entry.html
@@ -1,0 +1,11 @@
+{% extends '/_entry.html' %}
+
+{% block navigation scoped %}
+{{super()}}
+{% if entry.toc %}
+<nav id="toc">
+    <h2>Table of Contents</h2>
+    {{entry.toc(max_depth=2)}}
+</nav>
+{% endif %}
+{% endblock %}

--- a/tests/templates/toc/entry.html
+++ b/tests/templates/toc/entry.html
@@ -5,7 +5,7 @@
 {% if entry.toc %}
 <nav id="toc">
     <h2>Table of Contents</h2>
-    {{entry.toc(max_depth=2)}}
+    {{entry.toc(max_depth=request.args.get('depth',2)|int)}}
 </nav>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Implement table of contents and heading anchors; fixes #56 

## Detailed description

This adds `id` attributes to Markdown headings, and `entry.toc` that will render out the headings outline as an ordered list.

The following configuration options are added to entry content properties:

* `toc_link`: The base URL for table of contents links
* `heading_link_class`: The HTML `class` attribute to add to the self-link from headings in `entry.body`/`more`
* `heading_link_config`: Additional attributes to add to the self-link from headings (e.g. `title`, `data-*`)
* `heading_template`: A template for formatting headings in `entry.body`/`more`; can contain the following:
    * `link`: a tag that links back to this heading
    * `text`: the formatted text of the heading

    Default is `{link}</a>{text}`

`entry` now also gets a property `entry.toc` which takes standard formatting configuration, as well as:

*`max_depth`: How many layers deep to render

This change also refactors the way that footnotes are processed to reduce processing and redundancy.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
