### PR TITLE
Improve ToC and footnote performance

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -406,7 +406,7 @@ class Entry(caching.Memoizable):
         body, more, is_markdown = self._entry_content
 
         def _toc(max_depth=None, **kwargs) -> str:
-            LOGGER.debug("rendering table of contents; args=%s", kwargs)
+            LOGGER.debug("rendering table of contents; max_depth=%s kwargs=%s", max_depth, kwargs)
 
             return self._get_toc(body, more, max_depth, kwargs)
 

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -71,7 +71,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
     def footnote_ref(self, num):
         """ Render a link to this footnote """
         if self._config.get('_suppress_footnotes'):
-            return '\u200b' # zero-width space to prevent Misaka fallback
+            return '\u200b'  # zero-width space to prevent Misaka fallback
 
         return '{sup}{link}{content}</a></sup>'.format(
             sup=utils.make_tag('sup', {

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -49,7 +49,8 @@ class CallableProxy:
         return self._func()
 
     def _default(self):
-        return self._cached_default(flask.request.url)
+        from . import user  # pylint:disable=cyclic-import
+        return self._cached_default(flask.request.url, user.get_active())
 
     def __call__(self, *args, **kwargs) -> T:
         # use the new kwargs to override the defaults

--- a/tests/content/toc/postprocessing.md
+++ b/tests/content/toc/postprocessing.md
@@ -55,7 +55,7 @@ Should be allowed.
 
 Should be allowed.
 
-### Superscripts^2
+### Superscripts^&infin;
 
 I'll allow it.
 

--- a/tests/content/toc/postprocessing.md
+++ b/tests/content/toc/postprocessing.md
@@ -3,7 +3,13 @@ Date: 2020-02-03 23:06:08-08:00
 Entry-ID: 1886
 UUID: cc74548e-f159-55f2-a052-00fd680e74c9
 
-This TOC needs postprocessing.
+## Preamble[^pre]
+
+[^pre]: This footnote shouldn't appear in the ToC but should be accounted for.
+
+This TOC needs postprocessing[^post].
+
+[^post]: This footnote should also be accounted for.
 
 .....
 
@@ -55,9 +61,9 @@ I'll allow it.
 
 ### Footnotes[^notes]
 
-[^notes]: This makes no sense in the ToC
+[^notes]: This makes no sense in the ToC, but does in the text
 
-Makes no sense in the ToC, but it's hard to filter that out.
+Makes no sense in the ToC, but the Markdown renderer knows to filter it out.
 
 ### Code, e.g. `code`
 

--- a/tests/content/toc/screwy.md
+++ b/tests/content/toc/screwy.md
@@ -30,3 +30,5 @@ Good question!
 ## This is a screwy TOC
 
 # Yep
+
+Also look at it with [a greater depth](?depth=20). Or [just the top level](?depth=1).

--- a/tests/templates/_entry.html
+++ b/tests/templates/_entry.html
@@ -62,10 +62,14 @@
             {% endif %}
 
             <div class="entry e-content">
+            {% block entrybody scoped %}
             {{entry.body(footnotes_class='gronk',heading_link_class='permalink')}}
+            {% endblock %}
             {% if entry.more %}
             <div id="more">
+                {% block entrymore scoped %}
                 {{entry.more(footnotes_class='plonk',heading_link_class='permalink')}}
+                {% endblock %}
             </div>
             {% endif %}
             {% if entry.footnotes %}

--- a/tests/templates/toc/entry.html
+++ b/tests/templates/toc/entry.html
@@ -9,3 +9,15 @@
 </nav>
 {% endif %}
 {% endblock %}
+
+{% block entrybody scoped %}
+{{entry.body(max_width=32,
+    max_height=32,
+    heading_link_config={'title':'permalink','class':'permalink'})}}
+{% endblock %}
+
+{% block entrymore scoped %}
+{{entry.more(max_width=32,
+    max_height=32,
+    heading_link_config={'title':'permalink','class':'permalink'})}}
+{% endblock %}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Reduces the number of redundant calls for ToC and footnote determination; fixes #334 


## Detailed description

There are several performance optimizations that make constructs such as

```
{% if entry.toc %}
<h2>Table of Contents</h2>
{{entry.toc}}
{% endif %}
```

much faster. Some of the changes involved:

* `CallableProxy` now memoizes the default return (using common external variadics as cache keys; currently `flask.request.url` and `user.get_active` but adding more is easy)
* `entry` now keeps track of the various counters for markdown ToCs and footnotes on a per-section basis, so render functions don't have to do full content layout just to get the counters
* There is also now a dedicated ToC/footnote counter which is much faster than using the full Markdown renderer (and also doesn't result in spurious image renditions)

As a bonus change, ToCs now have footnote links entirely removed (the filtering being done at the Markdown level).

