### PR TITLE
Improve the way that entry IDs get reconciled

### DIFF
--- a/publ/config.py
+++ b/publ/config.py
@@ -1,9 +1,9 @@
 # config.py
 """ configuration container for Publ """
 
+import os
 import sys
 import typing
-import os
 
 from dateutil import tz
 

--- a/tests/content/duplicate id.md
+++ b/tests/content/duplicate id.md
@@ -1,7 +1,7 @@
 Title: duplicate id
 Status: HIDDEN
 Date: 2019-11-30 01:43:27-08:00
-Entry-ID: 190
 UUID: 44121549-33f4-5b5e-a4ec-5128f6555544
+Entry-ID: 190
 
 this should not get 1247


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Fix some edge conditions in how `Entry-ID` headers are updated; fixes #340 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
* Improves the type annotations on `Entry.get`
* Fixes a few things that were impacted by that
* Improve the logic behind page redirection/reindexing of entries whose `Entry-ID` header changes outside of index generation
* Refactors `rendering.render_entry` to make it a bit less monolithic

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
