### PR TITLE
Alternate Path-Alias mechanisms

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -60,41 +60,36 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
-                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
-                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
-                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
-                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
-                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
-                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
-                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
-                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
-                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
-                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
-                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
-                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
-                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
-                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
-                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
-                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
-                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
-                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
-                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
-                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
-                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
-                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
-                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
-                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
-                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
-                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
-                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
-                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
-                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
-                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
-                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
-                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
+                "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff",
+                "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b",
+                "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac",
+                "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0",
+                "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384",
+                "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26",
+                "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6",
+                "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b",
+                "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e",
+                "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd",
+                "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2",
+                "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66",
+                "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc",
+                "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8",
+                "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55",
+                "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4",
+                "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5",
+                "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d",
+                "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78",
+                "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa",
+                "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793",
+                "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f",
+                "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a",
+                "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f",
+                "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30",
+                "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f",
+                "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3",
+                "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"
             ],
-            "version": "==1.13.2"
+            "version": "==1.14.0"
         },
         "chardet": {
             "hashes": [
@@ -126,10 +121,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
         },
         "itsdangerous": {
             "hashes": [
@@ -231,9 +226,9 @@
         },
         "pony": {
             "hashes": [
-                "sha256:d1008d465d3c5db435fe2636f4c9e1a4a04a24f27c5d7cb4943ba5c596de7e17"
+                "sha256:1909758ad70f83245c6c6c863760fc5ba1ee2af388c6a5584cb2ffed38bed20a"
             ],
-            "version": "==0.7.11"
+            "version": "==0.7.12"
         },
         "publ": {
             "editable": true,
@@ -267,36 +262,36 @@
         },
         "regex": {
             "hashes": [
-                "sha256:07b39bf943d3d2fe63d46281d8504f8df0ff3fe4c57e13d1656737950e53e525",
-                "sha256:0932941cdfb3afcbc26cc3bcf7c3f3d73d5a9b9c56955d432dbf8bbc147d4c5b",
-                "sha256:0e182d2f097ea8549a249040922fa2b92ae28be4be4895933e369a525ba36576",
-                "sha256:10671601ee06cf4dc1bc0b4805309040bb34c9af423c12c379c83d7895622bb5",
-                "sha256:23e2c2c0ff50f44877f64780b815b8fd2e003cda9ce817a7fd00dea5600c84a0",
-                "sha256:26ff99c980f53b3191d8931b199b29d6787c059f2e029b2b0c694343b1708c35",
-                "sha256:27429b8d74ba683484a06b260b7bb00f312e7c757792628ea251afdbf1434003",
-                "sha256:3e77409b678b21a056415da3a56abfd7c3ad03da71f3051bbcdb68cf44d3c34d",
-                "sha256:4e8f02d3d72ca94efc8396f8036c0d3bcc812aefc28ec70f35bb888c74a25161",
-                "sha256:4eae742636aec40cf7ab98171ab9400393360b97e8f9da67b1867a9ee0889b26",
-                "sha256:6a6ae17bf8f2d82d1e8858a47757ce389b880083c4ff2498dba17c56e6c103b9",
-                "sha256:6a6ba91b94427cd49cd27764679024b14a96874e0dc638ae6bdd4b1a3ce97be1",
-                "sha256:7bcd322935377abcc79bfe5b63c44abd0b29387f267791d566bbb566edfdd146",
-                "sha256:98b8ed7bb2155e2cbb8b76f627b2fd12cf4b22ab6e14873e8641f266e0fb6d8f",
-                "sha256:bd25bb7980917e4e70ccccd7e3b5740614f1c408a642c245019cff9d7d1b6149",
-                "sha256:d0f424328f9822b0323b3b6f2e4b9c90960b24743d220763c7f07071e0778351",
-                "sha256:d58e4606da2a41659c84baeb3cfa2e4c87a74cec89a1e7c56bee4b956f9d7461",
-                "sha256:e3cd21cc2840ca67de0bbe4071f79f031c81418deb544ceda93ad75ca1ee9f7b",
-                "sha256:e6c02171d62ed6972ca8631f6f34fa3281d51db8b326ee397b9c83093a6b7242",
-                "sha256:e7c7661f7276507bce416eaae22040fd91ca471b5b33c13f8ff21137ed6f248c",
-                "sha256:ecc6de77df3ef68fee966bb8cb4e067e84d4d1f397d0ef6fce46913663540d77"
+                "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431",
+                "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242",
+                "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1",
+                "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d",
+                "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045",
+                "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b",
+                "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400",
+                "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa",
+                "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0",
+                "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69",
+                "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74",
+                "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb",
+                "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26",
+                "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5",
+                "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2",
+                "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce",
+                "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab",
+                "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e",
+                "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70",
+                "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc",
+                "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"
             ],
-            "version": "==2020.1.8"
+            "version": "==2020.2.20"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
-            "version": "==2.22.0"
+            "version": "==2.23.0"
         },
         "requests-oauthlib": {
             "hashes": [
@@ -341,16 +336,16 @@
         },
         "watchdog": {
             "hashes": [
-                "sha256:d64786787b14c8c6a71a8cc014056776ba6b52e85d1164ef2ab50aec02723a3d"
+                "sha256:c560efb643faed5ef28784b2245cf8874f939569717a4a12826a173ac644456b"
             ],
-            "version": "==0.10.1"
+            "version": "==0.10.2"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:1e0dedc2acb1f46827daa2e399c1485c8fa17c0d8e70b6b875b4e7f54bf408d2",
-                "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"
+                "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096",
+                "sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16"
             ],
-            "version": "==0.16.1"
+            "version": "==1.0.0"
         }
     },
     "develop": {
@@ -370,10 +365,10 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
-                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
+                "sha256:44f69771e2ac81ff30d929d485b7f9919f3ad6d019b6b20c74f3b8687c3f70df",
+                "sha256:aa8b870d0f46965bac2c073a93444636b0e1ca74e9777e34f03dd494b8a59d48"
             ],
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "certifi": {
             "hashes": [
@@ -382,76 +377,12 @@
             ],
             "version": "==2019.11.28"
         },
-        "cffi": {
-            "hashes": [
-                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
-                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
-                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
-                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
-                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
-                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
-                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
-                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
-                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
-                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
-                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
-                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
-                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
-                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
-                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
-                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
-                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
-                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
-                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
-                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
-                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
-                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
-                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
-                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
-                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
-                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
-                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
-                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
-                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
-                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
-                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
-                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
-                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
-            ],
-            "version": "==1.13.2"
-        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
-        },
-        "cryptography": {
-            "hashes": [
-                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
-                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
-                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
-                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
-                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
-                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
-                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
-                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
-                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
-                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
-                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
-                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
-                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
-                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
-                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
-                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
-                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
-                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
-                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
-                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
-                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
-            ],
-            "version": "==2.8"
         },
         "docutils": {
             "hashes": [
@@ -477,10 +408,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
         },
         "importlib-metadata": {
             "hashes": [
@@ -497,14 +428,6 @@
             ],
             "index": "pypi",
             "version": "==4.3.21"
-        },
-        "jeepney": {
-            "hashes": [
-                "sha256:0ba6d8c597e9bef1ebd18aaec595f942a264e25c1a48f164d46120eacaa2e9bb",
-                "sha256:6f45dce1125cf6c58a1c88123d3831f36a789f9204fbad3172eac15f8ccd08d0"
-            ],
-            "markers": "sys_platform == 'linux'",
-            "version": "==0.4.2"
         },
         "keyring": {
             "hashes": [
@@ -587,12 +510,6 @@
             ],
             "version": "==2.5.0"
         },
-        "pycparser": {
-            "hashes": [
-                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
-            ],
-            "version": "==2.19"
-        },
         "pyflakes": {
             "hashes": [
                 "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
@@ -632,10 +549,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
-            "version": "==2.22.0"
+            "version": "==2.23.0"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -643,14 +560,6 @@
                 "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
             ],
             "version": "==0.9.1"
-        },
-        "secretstorage": {
-            "hashes": [
-                "sha256:15da8a989b65498e29be338b3b279965f1b8f09b9668bd8010da183024c8bff6",
-                "sha256:b5ec909dde94d4ae2fa26af7c089036997030f0cf0a5cb372b4cccabd81c143b"
-            ],
-            "markers": "sys_platform == 'linux'",
-            "version": "==3.1.2"
         },
         "six": {
             "hashes": [
@@ -661,10 +570,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:251ee8440dbda126b8dfa8a7c028eb3f13704898caaef7caa699b35e119301e2",
-                "sha256:fe231261cfcbc6f4a99165455f8f6b9ef4e1032a6e29bccf168b4bf42012f09c"
+                "sha256:0d8b5afb66e23d80433102e9bd8b5c8b65d34c2a2255b2de58d97bd2ea8170fd",
+                "sha256:f35fb121bafa030bd94e74fcfd44f3c2830039a2ddef7fc87ef1c2d205237b24"
             ],
-            "version": "==4.42.1"
+            "version": "==4.43.0"
         },
         "twine": {
             "hashes": [
@@ -731,10 +640,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28",
-                "sha256:feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"
+                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
+                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
             ],
-            "version": "==2.1.0"
+            "version": "==3.0.0"
         }
     }
 }

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -258,7 +258,7 @@ This configuration value will stop being supported in Publ 0.6.
         self._regex_map.append((regex, func))
         return func
 
-    def _test_path_regex(self, path):
+    def test_path_regex(self, path):
         """ Evaluate the registered path-alias regular expressions. Returns the
         result of the first handler that successfully matches the path.
         """

--- a/publ/category.py
+++ b/publ/category.py
@@ -309,7 +309,9 @@ def scan_file(fullpath, relpath) -> bool:
     # update other relationships to the index
     path_alias.remove_aliases(record)
     for alias in meta.get_all('Path-Alias', []):
-        path_alias.set_alias(alias, category=record)
+        path_alias.set_alias(alias, model.AliasType.REDIRECT, category=record)
+    for alias in meta.get_all('Path-Mount', []):
+        path_alias.set_alias(alias, model.AliasType.MOUNT, category=record)
 
     orm.commit()
 

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -109,8 +109,8 @@ class Entry(caching.Memoizable):
                 # rule is in effect. This will have to change if we implement
                 # https://github.com/PlaidWeb/Publ/issues/286
                 return flask.url_for('category',
-                    template=self._message['Path-Canonical'],
-                    _external=absolute)
+                                     template=self._message['Path-Canonical'],
+                                     _external=absolute)
 
             return flask.url_for('entry',
                                  entry_id=self._record.id,

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -733,6 +733,7 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], assign_id: bool) -> 
         'redirect_url': entry.get('Redirect-To', ''),
         'title': title,
         'sort_title': entry.get('Sort-Title', title),
+        'canonical_path': entry.get('Path-Canonical', '')
     }
 
     entry_date = None

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -104,12 +104,12 @@ class Entry(caching.Memoizable):
             if not self.authorized:
                 expand = False
 
-            if 'Path-Canonical' in self._message:
+            if self._record.canonical_path:
                 # This is a hack that assumes that the standard '/<template>'
                 # rule is in effect. This will have to change if we implement
                 # https://github.com/PlaidWeb/Publ/issues/286
                 return flask.url_for('category',
-                                     template=self._message['Path-Canonical'],
+                                     template=self._record.canonical_path,
                                      _external=absolute)
 
             return flask.url_for('entry',

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -777,7 +777,9 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], assign_id: bool) -> 
     path_alias.remove_aliases(record)
     if record.visible:
         for alias in entry.get_all('Path-Alias', []):
-            path_alias.set_alias(alias, entry=record)
+            path_alias.set_alias(alias, model.AliasType.REDIRECT, entry=record)
+        for alias in entry.get_all('Path-Mount', []):
+            path_alias.set_alias(alias, model.AliasType.MOUNT, entry=record)
 
     orm.delete(p for p in model.EntryAuth if p.entry == record)  # type:ignore
     orm.commit()

--- a/publ/model.py
+++ b/publ/model.py
@@ -80,6 +80,8 @@ class Entry(DbEntity):
     auth = orm.Set("EntryAuth")
     auth_log = orm.Set("AuthLog")
 
+    canonical_path = orm.Optional(str)
+
     orm.composite_index(category, entry_type, utc_date)
     orm.composite_index(category, entry_type, local_date)
     orm.composite_index(category, entry_type, sort_title)

--- a/publ/model.py
+++ b/publ/model.py
@@ -142,7 +142,6 @@ class Category(DbEntity):
 class PathAlias(DbEntity):
     """ Path alias mapping """
     path = orm.PrimaryKey(str)
-    url = orm.Optional(str)
     entry = orm.Optional(Entry)
     category = orm.Optional(Category)
     template = orm.Optional(str)

--- a/publ/model.py
+++ b/publ/model.py
@@ -18,7 +18,7 @@ DbEntity: orm.core.Entity = db.Entity
 LOGGER = logging.getLogger(__name__)
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 
 class GlobalConfig(DbEntity):
@@ -29,13 +29,19 @@ class GlobalConfig(DbEntity):
 
 class PublishStatus(Enum):
     """ The status of the entry """
-    DRAFT = 0  # Entry should not be rendered
-    HIDDEN = 1  # Entry should be shown via direct link, but not shown on a view
-    UNLISTED = 1  # Synonym for HIDDEN
-    PUBLISHED = 2  # Entry is visible
-    SCHEDULED = 3  # Entry will be visible in the future
-    GONE = 4  # Entry is gone, won't be coming back
-    DELETED = 4  # synonym for GONE
+    DRAFT = 0       # Entry should not be rendered
+    HIDDEN = 1      # Entry should be shown via direct link, but not shown on a view
+    UNLISTED = 1    # Synonym for HIDDEN
+    PUBLISHED = 2   # Entry is visible
+    SCHEDULED = 3   # Entry will be visible in the future
+    GONE = 4        # Entry is gone, won't be coming back
+    DELETED = 4     # synonym for GONE
+
+
+class AliasType(Enum):
+    """ The type of PathAlias mapping """
+    REDIRECT = 0    # Redirect to the canon URL
+    MOUNT = 1       # Display the URL at the alias
 
 
 class FileFingerprint(DbEntity):
@@ -140,6 +146,7 @@ class PathAlias(DbEntity):
     entry = orm.Optional(Entry)
     category = orm.Optional(Category)
     template = orm.Optional(str)
+    alias_type = orm.Required(int)  # reflects AliasType
 
 
 class Image(DbEntity):

--- a/publ/model.py
+++ b/publ/model.py
@@ -80,8 +80,6 @@ class Entry(DbEntity):
     auth = orm.Set("EntryAuth")
     auth_log = orm.Set("AuthLog")
 
-    entry_template = orm.Optional(str)  # maps to Entry-Template
-
     orm.composite_index(category, entry_type, utc_date)
     orm.composite_index(category, entry_type, local_date)
     orm.composite_index(category, entry_type, sort_title)

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -123,15 +123,11 @@ def get_alias(path: str) -> typing.Optional[Disposition]:
     if not record or (record.entry and not record.entry.visible):
         url, permanent = current_app.test_path_regex(path)
         if url:
-            return Response(redirect(url, 301 if permanent else 302))
+            return Response(redirect(url, PERMANENT if permanent else TEMPORARY))
 
         return None
 
     alias_type = model.AliasType(record.alias_type)
-
-    if record.url:
-        # This is an outbound URL that might be changed by the user
-        return Response(redirect(record.url, TEMPORARY))
 
     if record.category:
         category = record.category.category
@@ -155,7 +151,7 @@ def get_alias(path: str) -> typing.Optional[Disposition]:
             endpoint = 'entry'
             args['entry_id'] = record.entry.id
 
-        return Response(redirect(url_for(endpoint, **args)))
+        return Response(redirect(url_for(endpoint, **args), PERMANENT))
 
     if record.entry:
         return RenderEntry(record.entry, category, record.template)

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -28,6 +28,9 @@ def set_alias(alias: str, alias_type: model.AliasType, **kwargs) -> model.PathAl
     spec = alias.split()
     path = spec[0]
 
+    if not path or path[0] != '/':
+        path = '/' + path
+
     values = {
         **kwargs,
         'path': path,

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -353,12 +353,18 @@ def _check_authorization(record, category):
 
 def _check_canon_entry_url(record):
     """ Check to see if an entry is being requested at its canonical URL """
-    canon_url = url_for('entry',
-                        entry_id=record.id,
-                        category=record.category,
-                        slug_text=record.slug_text if record.slug_text else None,
-                        _external=True,
-                        **request.args)
+    if record.canonical_path:
+        canon_url = url_for('category',
+                            template=record.canonical_path,
+                            _external=True,
+                            **request.args)
+    else:
+        canon_url = url_for('entry',
+                            entry_id=record.id,
+                            category=record.category,
+                            slug_text=record.slug_text if record.slug_text else None,
+                            _external=True,
+                            **request.args)
 
     LOGGER.debug("request.url=%s canon_url=%s", request.url, canon_url)
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -256,8 +256,10 @@ def render_category_path(category: str, template: typing.Optional[str]):
 
     if category:
         # See if there's any entries for the view...
-        if not orm.select(e for e in model.Entry if (e.category == category or  # type:ignore
-                          e.category.startswith(category + '/')) and e.visible):
+        if not orm.select(e for e in model.Entry  # type:ignore
+                          if (e.category == category
+                              or e.category.startswith(category + '/'))
+                          and e.visible):
             raise http_error.NotFound("No such category")
 
     if not template:
@@ -406,7 +408,7 @@ def render_entry(entry_id, slug_text='', category=''):
 
 
 def render_entry_record(record: model.Entry, category: str, template: typing.Optional[str],
-    _mounted=False):
+                        _mounted=False):
     """ Render an entry object """
 
     # Show an access denied error if the entry has been set to draft mode

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -55,11 +55,16 @@ def get_template(template: str, relation) -> typing.Optional[str]:
     return tmpl.filename if tmpl else None
 
 
-def get_redirect():
+def handle_path_alias(path: str = None):
     """ Check to see if the current request is a redirection """
-    alias = path_alias.get_redirect(request.path)
-    if alias:
-        return alias
+    alias = path_alias.get_alias(path or request.path)
+
+    if isinstance(alias, path_alias.Response):
+        return alias.response
+    if isinstance(alias, path_alias.RenderEntry):
+        return render_entry_record(alias.entry, alias.category, alias.template, _mounted=True)
+    if isinstance(alias, path_alias.RenderCategory):
+        return render_category_path(alias.category, alias.template)
 
     return None
 
@@ -216,10 +221,10 @@ def render_exception(error):
 def render_path_alias(path):
     """ Render a known path-alias (used primarily for forced .php redirects) """
 
-    redir = path_alias.get_redirect('/' + path)
-    if not redir:
-        raise http_error.NotFound("Path redirection not found")
-    return redir
+    result = handle_path_alias(path)
+    if result:
+        return result
+    raise http_error.NotFound("Path redirection not found")
 
 
 @orm.db_session(retry=5)
@@ -234,19 +239,25 @@ def render_category(category='', template=None):
     # pylint:disable=too-many-return-statements
 
     # See if this is an aliased path
-    redir = get_redirect()
-    if redir:
-        return redir
+    result = handle_path_alias()
+    if result:
+        return result
 
     # Forbidden template types
     if template in ['entry', 'error', 'login', 'unauthorized', 'logout']:
         LOGGER.info("Attempted to render special template %s", template)
         raise http_error.Forbidden("Invalid view requested")
 
+    return render_category_path(category, template)
+
+
+def render_category_path(category: str, template: typing.Optional[str]):
+    """ Renders the actual category by path """
+
     if category:
         # See if there's any entries for the view...
-        if not orm.select(e for e in model.Entry if e.category == category or
-                          e.category.startswith(category + '/')):
+        if not orm.select(e for e in model.Entry if (e.category == category or  # type:ignore
+                          e.category.startswith(category + '/')) and e.visible):
             raise http_error.NotFound("No such category")
 
     if not template:
@@ -259,9 +270,14 @@ def render_category(category='', template=None):
         test_path = '/'.join((category, template)) if category else template
         LOGGER.debug("Checking for malformed category %s", test_path)
         record = orm.select(
-            e for e in model.Entry if e.category == test_path).exists()
+            e for e in model.Entry if e.category == test_path).exists()  # type:ignore
         if record:
             return redirect(url_for('category', category=test_path, **request.args))
+
+        # could be a path alias
+        result = handle_path_alias()
+        if result:
+            return result
 
         # nope, we just don't know what this is
         raise http_error.NotFound(
@@ -346,9 +362,9 @@ def _check_canon_entry_url(record):
 
     if request.url != canon_url:
         # This could still be a redirected path...
-        path_redirect = get_redirect()
-        if path_redirect:
-            return path_redirect
+        result = handle_path_alias()
+        if result:
+            return result
 
         # Redirect to the canonical URL
         return redirect(canon_url)
@@ -371,25 +387,27 @@ def render_entry(entry_id, slug_text='', category=''):
 
     # check if it's a valid entry
     record = model.Entry.get(id=entry_id)
-    if not record:
-        # It's not a valid entry, so see if it's a redirection
-        path_redirect = get_redirect()
-        if path_redirect:
-            return path_redirect
-
-        LOGGER.info("Attempted to retrieve nonexistent entry %d", entry_id)
-        raise http_error.NotFound("No such entry")
 
     # see if the file still exists
     if not os.path.isfile(record.file_path):
         expire_record(record)
+        record = None
 
-        # See if there's a redirection
-        path_redirect = get_redirect()
-        if path_redirect:
-            return path_redirect
+    if not record:
+        # It's not a valid entry, so see if it's a redirection
+        result = handle_path_alias()
+        if result:
+            return result
 
+        LOGGER.info("Attempted to retrieve nonexistent entry %d", entry_id)
         raise http_error.NotFound("No such entry")
+
+    return render_entry_record(record, category, None)
+
+
+def render_entry_record(record: model.Entry, category: str, template: typing.Optional[str],
+    _mounted=False):
+    """ Render an entry object """
 
     # Show an access denied error if the entry has been set to draft mode
     if record.status == model.PublishStatus.DRAFT.value:
@@ -404,9 +422,10 @@ def render_entry(entry_id, slug_text='', category=''):
         return result
 
     # check if the canonical URL matches
-    result = _check_canon_entry_url(record)
-    if result:
-        return result
+    if not _mounted:
+        result = _check_canon_entry_url(record)
+        if result:
+            return result
 
     # if the entry canonically redirects, do that now
     if record.redirect_url:
@@ -417,7 +436,7 @@ def render_entry(entry_id, slug_text='', category=''):
 
     # does the entry-id header mismatch? If so the old one is invalid
     try:
-        current_id = int(entry_obj.get('Entry-ID'))
+        current_id: typing.Optional[int] = int(entry_obj.get('Entry-ID'))  # type:ignore
     except (KeyError, TypeError, ValueError) as err:
         LOGGER.debug("Error checking entry ID: %s", err)
         current_id = None
@@ -428,9 +447,10 @@ def render_entry(entry_id, slug_text='', category=''):
         from .entry import scan_file
         scan_file(entry_obj.file_path, None, True)
 
-        return redirect(url_for('entry', entry_id=entry_id))
+        return redirect(url_for('entry', entry_id=record.id))
 
-    entry_template = (entry_obj.get('Entry-Template')
+    entry_template = (template
+                      or entry_obj.get('Entry-Template')
                       or Category(category).get('Entry-Template')
                       or 'entry')
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable=import-outside-toplevel
+disable=import-outside-toplevel, bad-continuation
 
 [SIMILARITIES]
 ignore-imports=yes

--- a/tests.py
+++ b/tests.py
@@ -52,5 +52,5 @@ app.secret_key = "We are insecure"
 @app.route('/favicon.<ext>')
 def favicon(ext):
     logo = publ.image.get_image('images/rawr.jpg', 'tests/content')
-    img, _ = logo.get_rendition(format=ext, width=128, height=128)
+    img, _ = logo.get_rendition(format=ext, width=128, height=128, resize='fill')
     return flask.redirect(img)

--- a/tests/content/aliases/_.cat
+++ b/tests/content/aliases/_.cat
@@ -5,6 +5,7 @@ Path-Alias: /alias/p3 archive
 Path-Mount: /alias/p1m
 Path-Mount: /alias/p2m index
 Path-Mount: /alias/p3m archive
+Path-Mount: /alias/style.css style.css
 
 [/alias/p1](/alias/p1) and [/alias/p2](/alias/p2) should redirect to this category.
 

--- a/tests/content/aliases/_.cat
+++ b/tests/content/aliases/_.cat
@@ -1,0 +1,16 @@
+Title: Category aliases
+Path-Alias: /alias/p1
+Path-Alias: /alias/p2 index
+Path-Alias: /alias/p3 archive
+Path-Mount: /alias/p1m
+Path-Mount: /alias/p2m index
+Path-Mount: /alias/p3m archive
+
+[/alias/p1](/alias/p1) and [/alias/p2](/alias/p2) should redirect to this category.
+
+[/alias/p3](/alias/p3) should redirect to this category's archive.
+
+[/alias/p1m](/alias/p1m) and [/alias/p2m](/alias/p2m) should display this category.
+
+[/alias/p3m](/alias/p3m) should display this category's archive.
+

--- a/tests/content/aliases/alias template.md
+++ b/tests/content/aliases/alias template.md
@@ -1,0 +1,9 @@
+Title: Alias to template
+Path-Alias: /alias/c1 index
+Path-Mount: /alias/c1m _alternate
+Date: 2020-02-22 13:21:05-08:00
+Entry-ID: 892
+UUID: 1e4a7cfa-0bc0-5e02-bcdf-77aacfc3b414
+
+[/alias/c1](/alias/c1) should redirect to the index view with this item first.
+[/alias/c1m](/alias/c1m) should display this item with the `_alternate` template.

--- a/tests/content/aliases/aliases and mounts.md
+++ b/tests/content/aliases/aliases and mounts.md
@@ -1,0 +1,11 @@
+Title: Multiple aliases
+Path-Alias: /aliases/a1
+Path-Alias: /aliases/a2
+Path-Mount: /aliases/m1
+Date: 2020-02-22 13:08:49-08:00
+Entry-ID: 2505
+UUID: 42dfecaf-a768-507a-b3bc-ec945aaa42b0
+
+This should redirect from [/aliases/a1](/aliases/a1) and [/aliases/a2](/aliases/a2).
+
+This should mount at [/aliases/m1](/aliases/m1).

--- a/tests/content/aliases/canonical.md
+++ b/tests/content/aliases/canonical.md
@@ -7,3 +7,5 @@ UUID: ba777d3b-fbf0-5b87-bf70-653b6fd7a149
 This entry should only be viewable at [/alias/canonical](/alias/canonical).
 
 Links by entry ID should still point to [/alias/canonical](1209).
+
+Links [to the entry ID](/1209) (including [with a category](/aliases/1209)) should redirect to the canonical path.

--- a/tests/content/aliases/canonical.md
+++ b/tests/content/aliases/canonical.md
@@ -1,0 +1,9 @@
+Title: Canonical path
+Path-Canonical: /alias/canonical
+Date: 2020-02-22 13:44:13-08:00
+Entry-ID: 1209
+UUID: ba777d3b-fbf0-5b87-bf70-653b6fd7a149
+
+This entry should only be viewable at [/alias/canonical](/alias/canonical).
+
+Links by entry ID should still point to [/alias/canonical](1209).

--- a/tests/content/aliases/redirections.md
+++ b/tests/content/aliases/redirections.md
@@ -1,0 +1,11 @@
+Title: Alias redirections
+Redirect-To: https://beesbuzz.biz/
+Path-Alias: /redir/busybee
+Path-Mount: /mount/busybee
+Path-Canonical: /canon/busybee
+Date: 2020-02-22 14:27:21-08:00
+Entry-ID: 1117
+UUID: 9c195cdd-8b61-57d9-9c6e-6b73faca1348
+
+[/redir/busybee](/redir/busybee), [/mount/busybee](/mount/busybee), and [/canon/busybee](/canon/busybee) should all redirect to [https://beesbuzz.biz/](https://beesbuzz.biz/).
+

--- a/tests/content/auth/auth canonical.md
+++ b/tests/content/auth/auth canonical.md
@@ -1,0 +1,8 @@
+Title: Canonical for unauthorized entry
+Auth: foo
+Path-Canonical: /alias/u1c
+Date: 2020-02-22 14:47:48-08:00
+Entry-ID: 1879
+UUID: 51e610d3-0e85-50b1-8026-c6d4951664ca
+
+This entry should always appear as [/alias/u1c](/alias/u1c) but only if the user is authorized.

--- a/tests/content/auth/auth redirect.md
+++ b/tests/content/auth/auth redirect.md
@@ -1,0 +1,11 @@
+Title: Redirect for unauthorized entry
+Auth: foo
+Path-Alias: /alias/u1
+Path-Mount: /alias/u1m
+Date: 2020-02-22 14:46:21-08:00
+Entry-ID: 954
+UUID: 4ba25714-eaa4-5447-a737-ddb8ee1c9f8d
+
+[/alias/u1](/alias/u1) should redirect but only if the user is authorized.
+
+[/alias/u1m](/alias/u1m) should render directly, but only if the user is authorized.

--- a/tests/templates/archive.html
+++ b/tests/templates/archive.html
@@ -10,13 +10,15 @@
 
 {% set view = view(count=30,recurse=True) %}
 
-<h1>Publ: {{category.name or "Yet another site generator"}}</h1>
+<h1>Publ: {{category.name or "Yet another site generator"}} (archive view)</h1>
 
 <div id="nav" class="sidebar">
 
     <h2>Navigation</h2>
 
     <ul>
+        <li><a href=".">back to index</a></li>
+
     {% if category.parent %}
     <li class="cat-up"><a href="{{category.parent.link}}">Up one level</a></li>
     {% endif %}
@@ -42,7 +44,7 @@
     <li><a href="{{entry.archive('day',template.name,category)}}">by day</a></li>
     <li><a href="{{entry.archive('month',template.name,category)}}">by month</a></li>
     <li><a href="{{entry.archive('year',template.name,category)}}">by year</a></li>
-    <li><a href="{{entry.archive('id',template.name,category)}}">by id</a></li>
+    <li><a href="{{entry.archive('offset',template.name,category)}}">by offset</a></li>
 </ul></li>
 {% endfor %}
 </ul>
@@ -53,6 +55,13 @@
 {% if view.next %}
 <p><a href="{{view.next.link(absolute=True)}}">next page</a></p>
 {%endif %}
+
+{% if category.description %}
+<div id="description">
+    {{ category.description }}
+</div>
+{% endif %}
+
 
 </div>
 </body></html>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Adds `Path-Mount` and `Path-Canonical` to entry metadata; closes #209 

## Detailed description

Adds two new entry metadata fields:

`Path-Mount`: Like `Path-Alias`, but the standard entry URL will not redirect; the original canonical URL remains.

`Path-Canonical`: Like `Path-Mount`, except the standard entry URL will redirect to this entry.

In both of the above, specifying a template will treat the template as an *entry* template, rather than a category template; in `Path-Alias`, the optional template parameter still remains as a category view redirection.

This also adds `Path-Mount` to category views, which behaves identically to the entry version (except templates are of course used as a category template).

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

See tests in `/aliases/`.

## Got a site to show off?

<!-- If so, link to it here! -->
