### PR TITLE
Feature/tag filters

### DIFF
--- a/publ/queries.py
+++ b/publ/queries.py
@@ -1,6 +1,8 @@
 # queries.py
 """ Collection of commonly-used queries """
 
+from enum import Enum
+
 import arrow
 from pony import orm
 
@@ -9,6 +11,17 @@ from . import model, utils
 
 class InvalidQueryError(RuntimeError):
     """ An exception to raise if a query is invalid """
+
+class FilterCombiner(Enum):
+    """ Which operation to use when combining multiple operations in a filter """
+    ANY = 0     # any of the criteria are present
+    OR = 0      # synonym for ANY
+
+    ALL = 1     # all of the criteria are present
+    AND = 1     # synonym for ALL
+
+    NONE = 2    # none of the criteria are present
+    NOT = 2     # synonym for NONE
 
 
 def where_entry_visible(query, date=None):
@@ -140,13 +153,24 @@ def where_entry_type_not(query, entry_type):
     return query.filter(lambda e: e.entry_type != entry_type)
 
 
-def where_entry_tag(query, tag):
-    """ Generate a where clause for entries with the given tag """
-    if utils.is_list(tag):
-        tags = [t.lower() for t in tag]
-        return orm.select(e for e in query for t in e.tags if t.key in tags)
-    return orm.select(e for e in query for t in e.tags if t.key == tag.lower())
+def where_entry_tag(query, tags, operation : FilterCombiner):
+    """ Generate a where clause for entries with the given tags """
+    tags = [t.lower() for t in utils.as_list(tags)]
 
+    if operation == FilterCombiner.ANY:
+        return query.filter(lambda e: orm.exists(t for t in e.tags if t.key in tags))
+
+    if operation == FilterCombiner.ALL:
+        for tag in tags:
+            query = query.filter(lambda e: orm.exists(t for t in e.tags if t.key == tag))
+        return query
+
+    if operation == FilterCombiner.NONE:
+        for tag in tags:
+            query = query.filter(lambda e: not orm.exists(t for t in e.tags if t.key == tag))
+        return query
+
+    raise InvalidQueryError("Unsupported FilterCombiner " + operation)
 
 def where_entry_date(query, datespec):
     """ Where clause for entries which match a textual date spec
@@ -215,7 +239,8 @@ def build_query(spec):
         query = where_entry_type_not(query, spec['entry_type_not'])
 
     if spec.get('tag') is not None:
-        query = where_entry_tag(query, spec['tag'])
+        query = where_entry_tag(query, spec['tag'],
+            FilterCombiner[spec.get('tag_filter', 'ANY').upper()])
 
     if spec.get('date') is not None:
         query = where_entry_date(query, spec['date'])

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -12,6 +12,7 @@ from . import model, utils
 class InvalidQueryError(RuntimeError):
     """ An exception to raise if a query is invalid """
 
+
 class FilterCombiner(Enum):
     """ Which operation to use when combining multiple operations in a filter """
     ANY = 0     # any of the criteria are present
@@ -153,7 +154,7 @@ def where_entry_type_not(query, entry_type):
     return query.filter(lambda e: e.entry_type != entry_type)
 
 
-def where_entry_tag(query, tags, operation : FilterCombiner):
+def where_entry_tag(query, tags, operation: FilterCombiner):
     """ Generate a where clause for entries with the given tags """
     tags = [t.lower() for t in utils.as_list(tags)]
 
@@ -170,7 +171,8 @@ def where_entry_tag(query, tags, operation : FilterCombiner):
             query = query.filter(lambda e: not orm.exists(t for t in e.tags if t.key == tag))
         return query
 
-    raise InvalidQueryError("Unsupported FilterCombiner " + operation)
+    raise InvalidQueryError("Unsupported FilterCombiner " + str(operation))
+
 
 def where_entry_date(query, datespec):
     """ Where clause for entries which match a textual date spec
@@ -240,7 +242,7 @@ def build_query(spec):
 
     if spec.get('tag') is not None:
         query = where_entry_tag(query, spec['tag'],
-            FilterCombiner[spec.get('tag_filter', 'ANY').upper()])
+                                FilterCombiner[spec.get('tag_filter', 'ANY').upper()])
 
     if spec.get('date') is not None:
         query = where_entry_date(query, spec['date'])

--- a/tests/templates/tags/index.html
+++ b/tests/templates/tags/index.html
@@ -9,10 +9,10 @@
 <h2>Tag browser</h2>
 
     <ul>
-        {% for name,count in category.tags(recurse=True)|sort(attribute='count',reverse=True) %}
+        {% for name,count in category.tags(recurse=True,tag=view.tags,tag_filter='ALL')|sort(attribute='count',reverse=True) %}
         <li><a href="{{view(tag=name)}}">{{name}}</a> {{count}}
-            [<a href="{{view.tag_add(name)}}">+</a>]
-            [<a href="{{view.tag_remove(name)}}">-</a>]
+            {% if name not in view.tags %}[<a href="{{view.tag_add(name)}}">+</a>]{% endif %}
+            {% if name in view.tags %}[<a href="{{view.tag_remove(name)}}">-</a>]{% endif %}
             [<a href="{{view.tag_toggle(name)}}">x</a>]
 
         </li>
@@ -21,7 +21,7 @@
 
 <h2>Current tags: <code>{{view.tags}}</code></h2>
 
-{% for filter in ('ANY', 'ALL', 'NOT') %}
+{% for filter in ('ALL', 'ANY', 'NOT') %}
 
 <h3><code>tags_filter='{{filter}}'</code></h3>
 

--- a/tests/templates/tags/index.html
+++ b/tests/templates/tags/index.html
@@ -23,7 +23,7 @@
 
 {% for filter in ('ALL', 'ANY', 'NOT') %}
 
-<h3><code>tags_filter='{{filter}}'</code></h3>
+<h3><code>tag_filter='{{filter}}'</code></h3>
 
 <ul>
 {% for entry in view(recurse=True,tag_filter=filter).entries %}

--- a/tests/templates/tags/index.html
+++ b/tests/templates/tags/index.html
@@ -21,8 +21,12 @@
 
 <h2>Current tags: <code>{{view.tags}}</code></h2>
 
+{% for filter in ('ANY', 'ALL', 'NOT') %}
+
+<h3><code>tags_filter='{{filter}}'</code></h3>
+
 <ul>
-{% for entry in view(recurse=True).entries %}
+{% for entry in view(recurse=True,tag_filter=filter).entries %}
 <li><a href="{{entry.link}}">{{entry.title}}</a>: <ul>
     {% for tag in entry.get_all('Tag') %}
     <li><a href="{{view.tag_toggle(tag).link}}">{{ tag }}</a></li>
@@ -32,6 +36,9 @@
 {% if view.previous %}<li><a href="{{view.previous.link}}">previous</a></li>{% endif %}
 {% if view.next %}<a href="{{view.next.link}}">next</a>{% endif %}
 </ul>
+
+{% endfor %}
+
 
 {% for restrict in ['foo',['hello','bar']] %}
 {% set other = view(tag=restrict,recurse=True) %}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Allow multiple-tag filtering criteria of ANY, ALL, and NONE. Fixes #343 


## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

This adds a `tag_filter` parameter to the view specification, which can be any of `ANY`, `ALL`, or `NONE` (with aliases of `OR`, `AND`, and `NOT` respectively), which allows for requiring multiple tags, or a lack of specified tags, to be present in view entries.

And, because `category.tags` is built on top of `view.entries`, it gets that functionality for free, as it turns out.

The default value is `ANY`, so as to not break existing sites.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Updated `tests/templates/tags/index.html`

