### PR TITLE
Improved HTML stripping functionality

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -13,8 +13,8 @@ import authl.flask
 import flask
 import werkzeug.exceptions
 
-from . import (caching, config, image, index, maintenance, model, rendering,
-               tokens, user, utils, view)
+from . import (caching, config, html_entry, image, index, maintenance, model,
+               rendering, tokens, user, utils, view)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -155,6 +155,8 @@ This configuration value will stop being supported in Publ 0.6.
             login=utils.auth_link('login'),
             logout=utils.auth_link('logout')
         )
+
+        self.jinja_env.filters['strip_html'] = html_entry.strip_html  # pylint: disable=no-member
 
         caching.init_app(self, config.cache)
 

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -723,14 +723,16 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], assign_id: bool) -> 
         relpath = os.path.relpath(fullpath, config.content_folder)
 
     basename = os.path.basename(relpath)
-    title = entry['title'] or guess_title(basename)
+    title = entry.get('title', guess_title(basename))
 
     values = {
         'file_path': fullpath,
         'category': entry.get('Category', utils.get_category(relpath)),
         'status': model.PublishStatus[entry.get('Status', 'SCHEDULED').upper()].value,
         'entry_type': entry.get('Entry-Type', ''),
-        'slug_text': slugify.slugify(entry.get('Slug-Text', title)),
+        'slug_text': slugify.slugify(
+            entry.get('Slug-Text',
+                      markdown.render_title(title, markup=False, smartquotes=False))),
         'redirect_url': entry.get('Redirect-To', ''),
         'title': title,
         'sort_title': entry.get('Sort-Title', title),

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -144,11 +144,11 @@ class HTMLStripper(utils.HTMLTransform):
     def __init__(self,
                  allowed_tags: typing.Iterable[str] = None,
                  allowed_attrs: typing.Iterable[str] = None,
-                 remove_tags: typing.Iterable[str] = None):
+                 remove_elements: typing.Iterable[str] = None):
         super().__init__()
         self._allowed_tags = set(utils.as_list(allowed_tags))
         self._allowed_attrs = set(utils.as_list(allowed_attrs))
-        self._remove_tags = set(utils.as_list(remove_tags))
+        self._remove_elements = set(utils.as_list(remove_elements))
         self._remove_depth = 0
 
     def _filter(self, tag, attrs, **kwargs) -> str:
@@ -158,7 +158,7 @@ class HTMLStripper(utils.HTMLTransform):
                                    for key, val in attrs
                                    if key in self._allowed_attrs},
                                   **kwargs)
-        if self._remove_tags and tag in self._remove_tags:
+        if self._remove_elements and tag in self._remove_elements:
             self._remove_depth += 1
         return ''
 
@@ -168,7 +168,7 @@ class HTMLStripper(utils.HTMLTransform):
     def handle_endtag(self, tag):
         if self._allowed_tags and tag in self._allowed_tags:
             self.append('</{tag}>'.format(tag=tag))
-        elif self._remove_tags and tag in self._remove_tags:
+        elif self._remove_elements and tag in self._remove_elements:
             self._remove_depth -= 1
 
     def handle_startendtag(self, tag, attrs):
@@ -182,8 +182,8 @@ class HTMLStripper(utils.HTMLTransform):
 def strip_html(text,
                allowed_tags: typing.Iterable[str] = None,
                allowed_attrs: typing.Iterable[str] = None,
-               remove_tags: typing.Iterable[str] = None) -> str:
+               remove_elements: typing.Iterable[str] = None) -> str:
     """ Strip all HTML formatting off of a chunk of text """
-    strip = HTMLStripper(allowed_tags, allowed_attrs, remove_tags)
+    strip = HTMLStripper(allowed_tags, allowed_attrs, remove_elements)
     strip.feed(str(text))
     return strip.get_data()

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -142,20 +142,24 @@ class HTMLStripper(utils.HTMLTransform):
     """ Strip all HTML tags from a document, except those which are allowed """
 
     def __init__(self,
-                 allowed_tags: typing.Tuple[str] = None,
-                 allowed_attrs: typing.Tuple[str] = None):
+                 allowed_tags: typing.Iterable[str] = None,
+                 allowed_attrs: typing.Iterable[str] = None,
+                 remove_tags: typing.Iterable[str] = None):
         super().__init__()
-        self._allowed_tags = allowed_tags
-        self._allowed_attrs = allowed_attrs
+        self._allowed_tags = set(utils.as_list(allowed_tags))
+        self._allowed_attrs = set(utils.as_list(allowed_attrs))
+        self._remove_tags = set(utils.as_list(remove_tags))
+        self._remove_depth = 0
 
     def _filter(self, tag, attrs, **kwargs) -> str:
         if self._allowed_tags and tag in self._allowed_tags:
             return utils.make_tag(tag,
                                   {key: val
                                    for key, val in attrs
-                                   if self._allowed_attrs
-                                   and key in self._allowed_attrs},
+                                   if key in self._allowed_attrs},
                                   **kwargs)
+        if self._remove_tags and tag in self._remove_tags:
+            self._remove_depth += 1
         return ''
 
     def handle_starttag(self, tag, attrs):
@@ -164,18 +168,22 @@ class HTMLStripper(utils.HTMLTransform):
     def handle_endtag(self, tag):
         if self._allowed_tags and tag in self._allowed_tags:
             self.append('</{tag}>'.format(tag=tag))
+        elif self._remove_tags and tag in self._remove_tags:
+            self._remove_depth -= 1
 
     def handle_startendtag(self, tag, attrs):
         self.append(self._filter(tag, attrs, start_end=True))
 
     def handle_data(self, data):
-        self.append(data)
+        if not self._remove_depth:
+            self.append(data)
 
 
 def strip_html(text,
-               allowed_tags: typing.Tuple[str] = None,
-               allowed_attrs: typing.Tuple[str] = None) -> str:
+               allowed_tags: typing.Iterable[str] = None,
+               allowed_attrs: typing.Iterable[str] = None,
+               remove_tags: typing.Iterable[str] = None) -> str:
     """ Strip all HTML formatting off of a chunk of text """
-    strip = HTMLStripper(allowed_tags, allowed_attrs)
+    strip = HTMLStripper(allowed_tags, allowed_attrs, remove_tags)
     strip.feed(text)
     return strip.get_data()

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -185,5 +185,5 @@ def strip_html(text,
                remove_tags: typing.Iterable[str] = None) -> str:
     """ Strip all HTML formatting off of a chunk of text """
     strip = HTMLStripper(allowed_tags, allowed_attrs, remove_tags)
-    strip.feed(text)
+    strip.feed(str(text))
     return strip.get_data()

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -28,7 +28,7 @@ TOC_ALLOWED_TAGS = ('sup', 'sub',
                     'del', 'add', 'mark')
 
 # Remove these tags from plaintext-style conversions
-PLAINTEXT_REMOVE_TAGS = ('del', 's')
+PLAINTEXT_REMOVE_ELEMENTS = ('del', 's')
 
 
 class HtmlRenderer(misaka.HtmlRenderer):
@@ -125,7 +125,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
         """ Make a header with anchor """
 
         htag = 'h{level}'.format(level=level)
-        hid = self._header_id(html_entry.strip_html(content, remove_tags=PLAINTEXT_REMOVE_TAGS),
+        hid = self._header_id(html_entry.strip_html(content, remove_elements=PLAINTEXT_REMOVE_ELEMENTS),
                               level, len(self._toc_buffer) + 1)
 
         atag = utils.make_tag('a', {
@@ -407,7 +407,7 @@ def render_title(text, markup=True, smartquotes=True, markdown_extensions=None):
                                  or config.markdown_extensions)(text)
 
     if not markup:
-        text = html_entry.strip_html(text, remove_tags=PLAINTEXT_REMOVE_TAGS)
+        text = html_entry.strip_html(text, remove_elements=PLAINTEXT_REMOVE_ELEMENTS)
 
     if smartquotes:
         text = misaka.smartypants(text)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -21,7 +21,13 @@ TocEntry = typing.Tuple[int, str]
 TocBuffer = typing.List[TocEntry]
 
 # Allow these tags in TOC entries
-TOC_ALLOWED_TAGS = ('sup', 'sub', 'em', 'strong', 'b', 'i', 'code')
+TOC_ALLOWED_TAGS = ('sup', 'sub',
+                    'em', 'strong',
+                    'b', 'i',
+                    'code',
+                    'del', 'add', 'mark')
+# Remove these tags from plaintext-style conversions
+PLAINTEXT_REMOVE_TAGS = ('del')
 
 
 class HtmlRenderer(misaka.HtmlRenderer):
@@ -118,8 +124,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
         """ Make a header with anchor """
 
         htag = 'h{level}'.format(level=level)
-        hid = self._header_id(html_entry.strip_html(content), level,
-                              len(self._toc_buffer) + 1)
+        hid = self._header_id(html_entry.strip_html(content, remove_tags=PLAINTEXT_REMOVE_TAGS),
+                              level, len(self._toc_buffer) + 1)
 
         atag = utils.make_tag('a', {
             'href': urllib.parse.urljoin(self._config.get('toc_link', ''),
@@ -400,7 +406,7 @@ def render_title(text, markup=True, smartquotes=True, markdown_extensions=None):
                                  or config.markdown_extensions)(text)
 
     if not markup:
-        text = html_entry.strip_html(text, remove_tags=('del'))
+        text = html_entry.strip_html(text, remove_tags=PLAINTEXT_REMOVE_TAGS)
 
     if smartquotes:
         text = misaka.smartypants(text)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -400,7 +400,7 @@ def render_title(text, markup=True, smartquotes=True, markdown_extensions=None):
                                  or config.markdown_extensions)(text)
 
     if not markup:
-        text = html_entry.strip_html(text)
+        text = html_entry.strip_html(text, remove_tags=('del'))
 
     if smartquotes:
         text = misaka.smartypants(text)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -26,8 +26,9 @@ TOC_ALLOWED_TAGS = ('sup', 'sub',
                     'b', 'i',
                     'code',
                     'del', 'add', 'mark')
+
 # Remove these tags from plaintext-style conversions
-PLAINTEXT_REMOVE_TAGS = ('del')
+PLAINTEXT_REMOVE_TAGS = ('del', 's')
 
 
 class HtmlRenderer(misaka.HtmlRenderer):

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -213,7 +213,7 @@ def make_tag(name: str,
                     escaped = re.sub(r'&amp;([a-zA-Z0-9.\-_\:]+;)', r'&\1', val)
                 text += '="{}"'.format(escaped)
     if start_end:
-        text += ' /'
+        text += ' /' if attrs else '/'
     text += '>'
     return flask.Markup(text)
 

--- a/tests/content/toc/postprocessing.md
+++ b/tests/content/toc/postprocessing.md
@@ -25,7 +25,7 @@ This heading has an en-dash -- and maybe an em-dash --- yes
 
 ### Fractions like 1/2 and 1/4 are silly
 
-They are.
+They sure are.
 
 ## Image stuff
 
@@ -72,3 +72,11 @@ This is also supported and sensible.
 ### Math? $$d\frac{e^x}{dx} = e^x$$
 
 I mean, this isn't actually HTML so that's up to MathJax...
+
+### Also ~~misteaks~~ mistakes can be made
+
+Sure.
+
+### Is this ==notable?==
+
+Sure, why not.

--- a/tests/templates/index.txt
+++ b/tests/templates/index.txt
@@ -1,0 +1,9 @@
+{% for entry in view.entries %}
+## {{entry.title | strip_html }}
+
+{{ entry.body | strip_html(remove_tags=['sup']) }}
+{{ entry.more | strip_html(remove_tags=['sup']) }}
+
+{{ entry.footnotes | strip_html(['sup','a'],['href'])}}
+
+{% endfor %}

--- a/tests/test_html_entry.py
+++ b/tests/test_html_entry.py
@@ -65,6 +65,6 @@ def test_strip_html():
 
     assert strip_html(doc, ('a'), ('href')) == '<a href="zxcv">blahboo</a>'
 
-    assert strip_html(doc, remove_tags=('sup')) == 'blah'
+    assert strip_html(doc, remove_elements=('sup')) == 'blah'
 
     assert strip_html(doc, ('br')) == 'blahboo<br/>'

--- a/tests/test_html_entry.py
+++ b/tests/test_html_entry.py
@@ -1,0 +1,70 @@
+""" tests of publ.html_entry module """
+# pylint:disable=missing-function-docstring
+
+
+def test_process_passthrough():
+    from publ.html_entry import process
+
+    passthrough = '''<!DOCTYPE html>
+<html><head>
+<link rel="alternate" href="//example.com/" />
+<title>This entry should pass through unscathed</title></head>
+<body><h1>This entry should not be modified at all.</h1>
+
+<p>This entry is one of those ones which shouldn't have anything that gets
+modified in it, and shouldn't require an
+<a href="https://flask.palletsprojects.com/en/1.1.x/appcontext/">application
+context</a> to function.</p>
+
+<img src="//example.com/some-image.png">
+
+<br/><br/>
+
+<!-- commentary -->
+
+</body></html>'''
+    assert process(passthrough, {}, ()) == passthrough
+
+    assert process('<img data-publ-rewritten src="do_not_rewrite.jpg" width=400 height=400>',
+                   {}, ()) == '<img src="do_not_rewrite.jpg" width="400" height="400">'
+
+
+def test_process_attr_rewrites():
+    import flask
+    from publ.html_entry import process
+
+    app = flask.Flask(__name__, static_folder="bleh")
+    with app.test_request_context("https://foo.bar/baz"):
+        assert process('<a href="@something">foo</a>', {}, ()) == \
+            '<a href="/bleh/something">foo</a>'
+        assert process('<a href="@something">bar</a>', {'absolute': True}, ()) == \
+            '<a href="https://foo.bar/bleh/something">bar</a>'
+
+        assert process('<div $data-something="@something" />', {}, ()) == \
+            '<div data-something="/bleh/something" />'
+        assert process('<div $data-something="@something" />', {'absolute': True}, ()) == \
+            '<div data-something="https://foo.bar/bleh/something" />'
+
+
+def test_process_strip_html():
+    from publ.html_entry import process
+
+    assert process('<a href="foo">bar</a>', {'markup': False}, ()) == "bar"
+
+
+def test_strip_html():
+    from publ.html_entry import strip_html
+
+    assert strip_html("foobar") == "foobar"
+
+    doc = '<a href="zxcv" class="mew">blah<sup>boo</sup></a><br/>'
+
+    assert strip_html(doc) == "blahboo"
+
+    assert strip_html(doc, ('sup')) == "blah<sup>boo</sup>"
+
+    assert strip_html(doc, ('a'), ('href')) == '<a href="zxcv">blahboo</a>'
+
+    assert strip_html(doc, remove_tags=('sup')) == 'blah'
+
+    assert strip_html(doc, ('br')) == 'blahboo<br/>'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-""" tests of publ.utils class """
+""" tests of publ.utils module """
 # pylint:disable=missing-function-docstring
 
 import flask


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Have HTML renditions with `markup=False` remove `<del>` and `<s>` tags by default; provide finer-grained `strip_html` Jinja filter as well.

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Strikethrough text is, by its nature, not intended to be parsed as the final readable text. Having an entry titled, for example, "This is why I'm ~~sad~~ happy," will look like "This is why I'm sad happy" in non-markup contexts. So, this makes the default markup-stripping rules remove `<del>` and `<s>` elements entirely, rather than simply removing their tags, thus rendering `This is why I'm ~~sad~~ happy` as "This is why I'm happy."

For finer-grained control, the `html_entry.strip_html` function has also been provided as a global Jinja2 filter, so that template authors can get better control of this mechanism, or so that they can, for example, whitelist certain HTML tags or remove certain elements in HTML-friendly contexts where they'd otherwise want no formatting.

See related doc change: https://github.com/PlaidWeb/publ-site/commit/36badb9742e726d88da6c1a72cea19a7b0176c6f

This change also applies the above markup removal rules to the generation of default URL slugs.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
Impact is as described above.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added more unit tests, as well as a less-than-ideal `index.txt` template to the manual test site.

## Got a site to show off?

<!-- If so, link to it here! -->
