### PR TITLE
Feature/367 opengraph remote images

### DIFF
--- a/publ/cards.py
+++ b/publ/cards.py
@@ -2,6 +2,7 @@
 """ Rendering functions for Twitter/OpenGraph cards"""
 
 import logging
+import typing
 
 from . import utils
 
@@ -13,8 +14,12 @@ class CardData():
     # pylint: disable=too-few-public-methods
 
     def __init__(self):
-        self.description = None
-        self.images = []
+        self.description: typing.Optional[str] = None
+        self.images: typing.List[
+            typing.Tuple[
+                str,
+                typing.Optional[str],
+                typing.Optional[str]]] = []
 
     def commit(self):
         """ Apply all finalization to the card data """
@@ -38,7 +43,18 @@ class HtmlCardParser(utils.HTMLTransform):
             # We already got some data, so this is a malformed/old-style document
             self._consume = False
         if tag == 'img':
-            self._card.images += [val for attr, val in attrs if attr == 'src']
+            src = None
+            width = None
+            height = None
+            for attr, val in attrs:
+                if attr == 'src':
+                    src = val
+                elif attr == 'width':
+                    width = val
+                elif attr == 'height':
+                    height = val
+            if src:
+                self._card.images.append((src, width, height))
 
     def handle_endtag(self, tag):
         if tag == 'p':

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -423,8 +423,12 @@ class Entry(caching.Memoizable):
             tags += og_tag('og:url', self.link(absolute=True))
 
             card = self._get_card_data(kwargs)
-            for image in card.images[:kwargs.get('count', 1)]:
+            for (image, width, height) in card.images[:kwargs.get('count', 1)]:
                 tags += og_tag('og:image', image)
+                if width:
+                    tags += og_tag('og:image:width', width)
+                if height:
+                    tags += og_tag('og:image:height', height)
             description = self.get('Summary', card.description)
             if description:
                 tags += og_tag('og:description', description)
@@ -445,6 +449,7 @@ class Entry(caching.Memoizable):
                                                **kwargs,
                                                "max_scale": 1,
                                                "_suppress_footnotes": True,
+                                               "_no_resize_external": True,
                                                "absolute": True},
                                          footnote_buffer=footnote,
                                          toc_buffer=toc)

--- a/publ/image/external.py
+++ b/publ/image/external.py
@@ -29,46 +29,46 @@ class ExternalImage(Image):
     def _get_img_attrs(self, spec, style_parts):
         url = self._get_url(spec.get('absolute'))
 
-        attrs = {}
+        attrs = {'src': url}
         if 'class' in spec or 'img_class' in spec:
             attrs['class'] = spec.get('class', spec.get('img_class'))
         if 'id' in spec:
             attrs['id'] = spec['id']
 
-        # try to fudge the sizing
-        max_width = spec.get('max_width')
-        width = spec.get('width') or max_width
-        max_height = spec.get('max_height')
-        height = spec.get('height') or max_height
-        size_mode = spec.get('resize', 'fit')
 
-        if width and max_width and max_width < width:
-            if height:
-                height = height * max_width / width
-            width = max_width
-        if height and max_height and max_height < height:
+        if not spec.get('_no_resize_external'):
+            # try to fudge the sizing
+            max_width = spec.get('max_width')
+            width = spec.get('width') or max_width
+            max_height = spec.get('max_height')
+            height = spec.get('height') or max_height
+            size_mode = spec.get('resize', 'fit')
+
+            if width and max_width and max_width < width:
+                if height:
+                    height = height * max_width / width
+                width = max_width
+            if height and max_height and max_height < height:
+                if width:
+                    width = width * max_height / height
+                height = max_height
+
+            if width and height and size_mode != 'stretch':
+                style_parts += [
+                    'background-image:url(\'{}\')'.format(html.escape(url)),
+                    'background-size:{}'.format(self.CSS_SIZE_MODE[size_mode]),
+                    'background-position:{:.1f}% {:.1f}%'.format(
+                        spec.get('fill_crop_x', 0.5) * 100,
+                        spec.get('fill_crop_y', 0.5) * 100),
+                    'background-repeat:no-repeat'
+                ]
+                attrs['src'] = flask.url_for(
+                    'chit', _external=spec.get('absolute'))
+
             if width:
-                width = width * max_height / height
-            height = max_height
-
-        if width and height and size_mode != 'stretch':
-            style_parts += [
-                'background-image:url(\'{}\')'.format(html.escape(url)),
-                'background-size:{}'.format(self.CSS_SIZE_MODE[size_mode]),
-                'background-position:{:.1f}% {:.1f}%'.format(
-                    spec.get('fill_crop_x', 0.5) * 100,
-                    spec.get('fill_crop_y', 0.5) * 100),
-                'background-repeat:no-repeat'
-            ]
-            attrs['src'] = flask.url_for(
-                'chit', _external=spec.get('absolute'))
-        else:
-            attrs['src'] = url
-
-        if width:
-            attrs['width'] = width
-        if height:
-            attrs['height'] = height
+                attrs['width'] = width
+            if height:
+                attrs['height'] = height
 
         return attrs
 

--- a/tests/content/cards/markdown with remote image.md
+++ b/tests/content/cards/markdown with remote image.md
@@ -1,0 +1,6 @@
+Title: Markdown with remote or static image
+Date: 2020-04-23 16:37:10-07:00
+Entry-ID: 1058
+UUID: a24683bb-ac2a-5766-a41f-479242947d47
+
+![](@images/IMG_0377.jpg{360,360,resize='fill'})


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Disable the resizing of remote images in cards. Fixes #367.

Also uses the final rendition sizes to apply width and height attributes to the OpenGraph tags, if possible. Fixes #366.

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
In a card render context, sets a `_no_resize_external` image spec to tell the image renderer to not apply sizing to external images. The resulting `<img src>` will thus always relate to the original, unsized external image.

`og:image:width` et al get their size from the appropriate `<img>` attributes.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
See `tests/content/cards/markdown with remote image.md`

## Got a site to show off?

<!-- If so, link to it here! -->
