### PR TITLE
Make logging out work again

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -171,11 +171,11 @@ This configuration value will stop being supported in Publ 0.6.
         def logout(redir=''):
             """ Log out from the thing """
             if flask.request.method == 'POST':
-                LOGGER.info("Logging out")
+                LOGGER.info("Logging out %s", flask.session.get('me'))
                 LOGGER.info("Redir: %s", redir)
                 LOGGER.info("Request path: %s", flask.request.path)
 
-                flask.session['me'] = ''
+                flask.session.pop('me')
                 return flask.redirect('/' + redir)
 
             tmpl = rendering.map_template('/', 'logout')


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Make logout function work again; fixes #372 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
One of the changes to cache-busting meant that a db_session was required for `render_publ_template`, but the logout view controller didn't have a db_session, since why would it? This just wraps the entire `render_publ_template` in its own db_session (which is a no-op if there already is one), and also puts the cachebuster computation inside another one to improve contention around some potential race condition cases.

While I was at it I also changed the session destruction to use `flask.session.pop` instead of setting a new empty string.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
