### PR TITLE
Improve view.deleted on count-based paginations

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -88,6 +88,7 @@ def image_function(template=None,
 
     return lambda filename: image.get_image(filename, path)
 
+
 @orm.db_session
 def render_publ_template(template: Template, **kwargs) -> typing.Tuple[str, str]:
     """ Render out a template, providing the image function based on the args.


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Filter `view.deleted` correctly on count-based pagination views

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
On a count-based pagination, `view.deleted` was using the count to restrict the number of entries to fetch, rather than restricting it based on the items that are visible on the page. This changes `view.deleted` to restrict deleted entries to the ones which came before the next page.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Manually tested with beesbuzz.biz content. As with most things this would benefit greatly from actual unit tests.

## Got a site to show off?

<!-- If so, link to it here! -->
