### PR TITLE
Rewrite the indexer scheduling logic

### DIFF
--- a/publ/config.py
+++ b/publ/config.py
@@ -14,6 +14,7 @@ database_config = {
     'filename': ':memory:'
 }
 index_rescan_interval = 7200
+index_wait_time = 1
 
 # Site content locations
 content_folder = 'content'

--- a/publ/index.py
+++ b/publ/index.py
@@ -5,10 +5,12 @@ import concurrent.futures
 import logging
 import os
 import threading
+import time
 import typing
 
 import watchdog.events
 import watchdog.observers
+from flask import current_app
 from pony import orm
 
 from . import category, entry, model, utils
@@ -18,39 +20,99 @@ LOGGER = logging.getLogger(__name__)
 ENTRY_TYPES = ['.md', '.htm', '.html']
 CATEGORY_TYPES = ['.cat', '.meta']
 
-THREAD_POOL = concurrent.futures.ThreadPoolExecutor(
-    max_workers=1,
-    thread_name_prefix="Indexer")
 
-# Get the _work_queue attribute from the pool, if any
-WORK_QUEUE = getattr(THREAD_POOL, '_work_queue', None)
+class Indexer:
+    """ Class which handles the scheduling of file indexing """
+    # pylint:disable=too-few-public-methods
+    QUEUE_ITEM = typing.Tuple[str, typing.Optional[str], bool]
 
-
-class ConcurrentSet:
-    """ Simple quasi-atomic set """
-
-    def __init__(self):
+    def __init__(self, wait_time:float):
+        self.thread_pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="Indexer")
+        self._pending: typing.Set[Indexer.QUEUE_ITEM] = set()
         self._lock = threading.Lock()
-        self._set = set()
+        self._running: concurrent.futures.Future = None
+        self._wait_time = wait_time
 
-    def add(self, item) -> bool:
-        """ Add an item to the set, and return whether it was newly added """
+    def scan_file(self, fullpath: str, relpath: typing.Optional[str], fixups: bool):
+        """ Scan a file for the index
+
+        fullpath -- The full path to the file
+        relpath -- The path to the file, relative to its base directory
+        fixups -- Whether to perform fixup routines on the file
+
+        This calls into various modules' scanner functions; the expectation is that
+        the scan_file function will return a truthy value if it was scanned
+        successfully, False if it failed, and None if there is nothing to scan.
+        """
+
         with self._lock:
-            if item in self._set:
+            self._pending.add((fullpath, relpath, fixups))
+        self._schedule(self._wait_time)
+
+    def _schedule(self, wait:float=0):
+        with self._lock:
+            if not self._running or self._running.done():
+                if wait:
+                    # busywait the worker thread to wait for things to settle down
+                    # (and to batch up a bunch of updates in a row)
+                    self.thread_pool.submit(time.sleep, wait)
+
+                # run the actual pending task
+                self._running = self.thread_pool.submit(self._scan_pending)
+
+                LOGGER.debug("worker started %s", self._running)
+
+    def _scan_pending(self):
+        """ Scan all the pending items """
+        try:
+            with self._lock:
+                items = self._pending
+                self._pending = set()
+            LOGGER.debug("Processing %d files", len(items))
+
+            # process the known items
+            for item in items:
+                self._scan_file(*item)
+
+            # and then schedule a catchup for anything that happened
+            # while this scan was happening
+            if items:
+                self.thread_pool.submit(self._schedule)
+
+        except Exception:  # pylint:disable=broad-except
+            LOGGER.exception("_scan_pending failed")
+
+    def _scan_file(self, fullpath: str, relpath: typing.Optional[str], fixups: bool):
+        LOGGER.debug("Scanning file: %s (%s) %s", fullpath, relpath, fixups)
+
+        def do_scan() -> typing.Optional[bool]:
+            """ helper function to do the scan and gather the result """
+            _, ext = os.path.splitext(fullpath)
+
+            try:
+                if ext in ENTRY_TYPES:
+                    LOGGER.info("Scanning entry: %s", fullpath)
+                    return entry.scan_file(fullpath, relpath, fixups)
+
+                if ext in CATEGORY_TYPES:
+                    LOGGER.info("Scanning meta info: %s", fullpath)
+                    return category.scan_file(fullpath, relpath)
+
+                return None
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.exception("Got error parsing %s", fullpath)
                 return False
-            self._set.add(item)
-            return True
 
-    def remove(self, item) -> bool:
-        """ Remove an item from the set, returning whether it was present """
-        with self._lock:
-            if item in self._set:
-                self._set.remove(item)
-                return True
-            return False
-
-
-SCHEDULED_FILES = ConcurrentSet()
+        result = do_scan()
+        if result is False and not fixups:
+            LOGGER.info("Scheduling fixup for %s", fullpath)
+            self.scan_file(fullpath, relpath, True)
+        else:
+            LOGGER.debug("%s complete", fullpath)
+            set_fingerprint(fullpath)
+        return result
 
 
 @orm.db_session
@@ -66,64 +128,25 @@ def last_modified() -> typing.Tuple[typing.Optional[str],
     return None, None, None
 
 
+def _work_queue():
+    return getattr(current_app.indexer.thread_pool, '_work_queue', None)
+
+
 def queue_length() -> typing.Optional[int]:
-    """ Get the approximate length of the indexer work queue """
-    return WORK_QUEUE.qsize() if WORK_QUEUE else None
+    """ Return the approximate length of the work queue """
+    work_queue = _work_queue()
+    return work_queue.qsize() if work_queue else None
 
 
 def in_progress() -> bool:
     """ Return if there's an index in progress """
-    remaining = queue_length()
-    return remaining is not None and remaining > 0
+    return bool(queue_length)
 
 
 def is_scannable(fullpath) -> bool:
     """ Determine if a file needs to be scanned """
     _, ext = os.path.splitext(fullpath)
     return ext in ENTRY_TYPES or ext in CATEGORY_TYPES
-
-
-def scan_file(fullpath, relpath, assign_id) -> typing.Optional[bool]:
-    """ Scan a file for the index
-
-    fullpath -- The full path to the file
-    relpath -- The path to the file, relative to its base directory
-    assign_id -- Whether to assign an ID to the file if not yet assigned
-
-    This calls into various modules' scanner functions; the expectation is that
-    the scan_file function will return a truthy value if it was scanned
-    successfully, False if it failed, and None if there is nothing to scan.
-    """
-
-    LOGGER.debug("Scanning file: %s (%s) %s", fullpath, relpath, assign_id)
-
-    def do_scan() -> typing.Optional[bool]:
-        """ helper function to do the scan and gather the result """
-        _, ext = os.path.splitext(fullpath)
-
-        try:
-            if ext in ENTRY_TYPES:
-                LOGGER.info("Scanning entry: %s", fullpath)
-                return entry.scan_file(fullpath, relpath, assign_id)
-
-            if ext in CATEGORY_TYPES:
-                LOGGER.info("Scanning meta info: %s", fullpath)
-                return category.scan_file(fullpath, relpath)
-
-            return None
-        except:  # pylint: disable=bare-except
-            LOGGER.exception("Got error parsing %s", fullpath)
-            return False
-
-    result = do_scan()
-    if result is False and not assign_id:
-        LOGGER.info("Scheduling fixup for %s", fullpath)
-        THREAD_POOL.submit(scan_file, fullpath, relpath, True)
-    else:
-        LOGGER.debug("%s complete", fullpath)
-        set_fingerprint(fullpath)
-        SCHEDULED_FILES.remove(fullpath)
-    return result
 
 
 @orm.db_session
@@ -158,16 +181,16 @@ def set_fingerprint(fullpath, fingerprint=None):
 class IndexWatchdog(watchdog.events.PatternMatchingEventHandler):
     """ Watchdog handler """
 
-    def __init__(self, content_dir):
+    def __init__(self, indexer, content_dir):
         super().__init__(ignore_directories=True)
+        self._indexer = indexer
         self.content_dir = content_dir
 
     def update_file(self, fullpath):
         """ Update a file """
-        if SCHEDULED_FILES.add(fullpath):
-            LOGGER.debug("Scheduling reindex of %s", fullpath)
-            relpath = os.path.relpath(fullpath, self.content_dir)
-            THREAD_POOL.submit(scan_file, fullpath, relpath, False)
+        LOGGER.debug("Scheduling reindex of %s", fullpath)
+        relpath = os.path.relpath(fullpath, self.content_dir)
+        self._indexer.scan_file(fullpath, relpath, False)
 
     def on_created(self, event):
         """ on_created handler """
@@ -198,7 +221,7 @@ class IndexWatchdog(watchdog.events.PatternMatchingEventHandler):
 def background_scan(content_dir):
     """ Start background scanning a directory for changes """
     observer = watchdog.observers.Observer()
-    observer.schedule(IndexWatchdog(content_dir),
+    observer.schedule(IndexWatchdog(current_app.indexer, content_dir),
                       content_dir, recursive=True)
     logging.info("Watching %s for changes", content_dir)
     observer.start()
@@ -238,6 +261,8 @@ def scan_index(content_dir):
     """ Scan all files in a content directory """
     LOGGER.debug("Reindexing content from %s", content_dir)
 
+    indexer = current_app.indexer
+
     def scan_directory(root, files):
         """ Helper function to scan a single directory """
         LOGGER.debug("scanning directory %s", root)
@@ -251,14 +276,14 @@ def scan_index(content_dir):
 
                 fingerprint = utils.file_fingerprint(fullpath)
                 last_fingerprint = get_last_fingerprint(fullpath)
-                if fingerprint != last_fingerprint and SCHEDULED_FILES.add(fullpath):
+                if fingerprint != last_fingerprint:
                     LOGGER.debug("%s: %s -> %s", fullpath, last_fingerprint, fingerprint)
-                    scan_file(fullpath, relpath, False)
+                    indexer.scan_file(fullpath, relpath, False)
         except:  # pylint:disable=bare-except
             LOGGER.exception("Got error parsing directory %s", root)
 
     for root, _, files in os.walk(content_dir, followlinks=True):
-        THREAD_POOL.submit(scan_directory, root, files)
+        indexer.thread_pool.submit(scan_directory, root, files)
 
     for table in (model.Entry, model.Category, model.Image, model.FileFingerprint):
-        THREAD_POOL.submit(prune_missing, table)
+        indexer.thread_pool.submit(prune_missing, table)

--- a/publ/maintenance.py
+++ b/publ/maintenance.py
@@ -7,7 +7,8 @@ import typing
 class Maintenance:
     """ Container for periodic maintenance tasks """
 
-    def __init__(self):
+    def __init__(self, app):
+        self.app = app
         self.tasks: typing.Dict[typing.Callable[[], None],
                                 typing.Dict[str, float]] = {}
 
@@ -18,8 +19,9 @@ class Maintenance:
     def run(self, force: bool = False):
         """ Run all pending tasks; 'force' will run all tasks whether they're
         pending or not. """
-        now = time.time()
-        for func, spec in self.tasks.items():
-            if force or now >= spec.get('next_run', 0):
-                func()
-                spec['next_run'] = now + spec['interval']
+        with self.app.app_context():
+            now = time.time()
+            for func, spec in self.tasks.items():
+                if force or now >= spec.get('next_run', 0):
+                    func()
+                    spec['next_run'] = now + spec['interval']

--- a/publ/model.py
+++ b/publ/model.py
@@ -18,7 +18,7 @@ DbEntity: orm.core.Entity = db.Entity
 LOGGER = logging.getLogger(__name__)
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 
 class GlobalConfig(DbEntity):
@@ -64,7 +64,7 @@ class FileFingerprint(DbEntity):
 
 class Entry(DbEntity):
     """ Indexed entry """
-    file_path = orm.Required(str)
+    file_path = orm.Required(str, index=True)
     category = orm.Optional(str)
     status = orm.Required(int)
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -15,7 +15,7 @@ from . import (caching, config, image, index, model, path_alias, queries, user,
                utils, view)
 from .caching import cache
 from .category import Category
-from .entry import Entry, expire_record
+from .entry import Entry, expire_record as entry_expire_record
 from .template import Template, map_template
 
 LOGGER = logging.getLogger(__name__)
@@ -89,7 +89,6 @@ def image_function(template=None,
     return lambda filename: image.get_image(filename, path)
 
 
-@orm.db_session
 def render_publ_template(template: Template, **kwargs) -> typing.Tuple[str, str]:
     """ Render out a template, providing the image function based on the args.
 
@@ -134,7 +133,7 @@ def render_publ_template(template: Template, **kwargs) -> typing.Tuple[str, str]
         raise http_error.BadRequest(str(err))
 
 
-@orm.db_session(retry=5)
+@orm.db_session
 def render_error(category, error_message, error_codes,
                  exception=None,
                  headers=None) -> typing.Tuple[str, int, typing.Dict[str, str]]:
@@ -177,6 +176,7 @@ def render_error(category, error_message, error_codes,
     return '%d %s' % (error_code, error_message), error_code, headers
 
 
+@orm.db_session
 def render_exception(error):
     """ Catch-all renderer for the top-level exception handler """
 
@@ -230,7 +230,7 @@ def render_exception(error):
     })
 
 
-@orm.db_session(retry=5)
+@orm.db_session
 def render_path_alias(path):
     """ Render a known path-alias (used primarily for forced .php redirects) """
 
@@ -309,6 +309,7 @@ def render_category_path(category: str, template: typing.Optional[str]):
                       'ETag': etag}
 
 
+@orm.db_session
 def render_login_form(redir=None, **kwargs):
     """ Renders the login form using the mapped login template """
 
@@ -406,7 +407,7 @@ def render_entry(entry_id, slug_text='', category=''):
 
     # see if the file still exists
     if record and not os.path.isfile(record.file_path):
-        expire_record(record)
+        entry_expire_record(record)
         record = None
 
     if not record:
@@ -498,7 +499,6 @@ def render_entry_record(record: model.Entry, category: str, template: typing.Opt
     return rendered, headers
 
 
-@orm.db_session(retry=5)
 def admin_dashboard(by=None):  # pylint:disable=invalid-name
     """ Render the authentication dashboard """
     cur_user = user.get_active()
@@ -540,7 +540,7 @@ def render_transparent_chit():
                        'Last-Modified': 'Tue, 31 Jul 1990 08:00:00 -0000'}
 
 
-@orm.db_session(retry=5)
+@orm.db_session
 def retrieve_asset(filename):
     """ Retrieves a non-image asset associated with an entry """
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Rewrite the indexer scheduling logic to prevent a bunch of problems; hopefully fixes #370 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

Now when it detects files changing, it will queue the changes up for a second (by default) before it starts processing them, and the processing will go in batches based on what additional changes occur during the previous batch.

Additionally, there is a safeguard where if the file fingerprint on a source file changes while the scan-and-fixup process happens, it will abort the write.

If a file disappears before the index gets updated (for example, when the process is shut down), the associated entry record will be marked GONE instead of being deleted from the database. This prevents the renderer from dying due to access to a deleted record.

This is still a piecemeal solution and #371 will still be desirable in the long term; in particular this will make the initial delay work more correctly and not pause the directory traversal phase of a full reindex. However this partial queueing logic is still a step in the right direction.

While I was rewriting this code anyway, the indexer itself is now encapsulated in `index.Indexer` which lives on the application rather than using module-global variables, which is a better pattern moving forward.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Manually tested a few scenarios known to cause issues. Due to timing-sensitivity it is difficult to write an automated test.

## Got a site to show off?

<!-- If so, link to it here! -->
