### PR TITLE
Add the ability to attach entries to other entries

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,17 +18,17 @@
     "default": {
         "arrow": {
             "hashes": [
-                "sha256:5390e464e2c5f76971b60ffa7ee29c598c7501a294bc9f5e6dadcb251a5d027b",
-                "sha256:70729bcc831da496ca3cb4b7e89472c8e2d27d398908155e0796179f6d2d41ee"
+                "sha256:a24c1de90850f6fb2033fd6bf8a11f281e84cb54825e5eabdda219e673b52aac",
+                "sha256:eb5d339f00072cc297d7de252a2e75f272085d1231a3723f1026d1fa91367118"
             ],
-            "version": "==0.15.5"
+            "version": "==0.15.6"
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
+                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
             ],
-            "version": "==1.3.0"
+            "version": "==1.4.0"
         },
         "authl": {
             "hashes": [
@@ -45,11 +45,11 @@
         },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:594ca51a10d2b3443cbac41214e12dbb2a1cd57e1a7344659849e2e20ba6a8d8",
-                "sha256:a4bbe77fd30670455c5296242967a123ec28c37e9702a8a81bd2f20a4baf0368",
-                "sha256:d4e96ac9b0c3a6d3f0caae2e4124e6055c5dcafde8e2f831ff194c104f0775a0"
+                "sha256:73cc4d115b96f79c7d77c1c7f7a0a8d4c57860d1041df407dd1aae7f07a77fd7",
+                "sha256:a6237df3c32ccfaee4fd201c8f5f9d9df619b93121d01353a64a73ce8c6ef9a8",
+                "sha256:e718f2342e2e099b640a34ab782407b7b676f47ee272d6739e60b8ea23829f2c"
             ],
-            "version": "==4.9.0"
+            "version": "==4.9.1"
         },
         "certifi": {
             "hashes": [
@@ -100,10 +100,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "version": "==7.1.1"
+            "version": "==7.1.2"
         },
         "flask": {
             "hashes": [
@@ -207,30 +207,30 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:04a10558320eba9137d6a78ca6fc8f4a5801f1b971152938851dc4629d903579",
-                "sha256:0f89ddc77cf421b8cd34ae852309501458942bf370831b4a9b406156b599a14e",
-                "sha256:251e5618125ec12ac800265d7048f5857a8f8f1979db9ea3e11382e159d17f68",
-                "sha256:291bad7097b06d648222b769bbfcd61e40d0abdfe10df686d20ede36eb8162b6",
-                "sha256:2f0b52a08d175f10c8ea36685115681a484c55d24d0933f9fd911e4111c04144",
-                "sha256:3713386d1e9e79cea1c5e6aaac042841d7eef838cc577a3ca153c8bedf570287",
-                "sha256:433bbc2469a2351bea53666d97bb1eb30f0d56461735be02ea6b27654569f80f",
-                "sha256:4510c6b33277970b1af83c987277f9a08ec2b02cc20ac0f9234e4026136bb137",
-                "sha256:50a10b048f4dd81c092adad99fa5f7ba941edaf2f9590510109ac2a15e706695",
-                "sha256:670e58d3643971f4afd79191abd21623761c2ebe61db1c2cb4797d817c4ba1a7",
-                "sha256:6c1924ed7dbc6ad0636907693bbbdd3fdae1d73072963e71f5644b864bb10b4d",
-                "sha256:721c04d3c77c38086f1f95d1cd8df87f2f9a505a780acf8575912b3206479da1",
-                "sha256:8d5799243050c2833c2662b824dfb16aa98e408d2092805edea4300a408490e7",
-                "sha256:90cd441a1638ae176eab4d8b6b94ab4ec24b212ed4c3fbee2a6e74672481d4f8",
-                "sha256:a5dc9f28c0239ec2742d4273bd85b2aa84655be2564db7ad1eb8f64b1efcdc4c",
-                "sha256:b2f3e8cc52ecd259b94ca880fea0d15f4ebc6da2cd3db515389bb878d800270f",
-                "sha256:b7453750cf911785009423789d2e4e5393aae9cbb8b3f471dab854b85a26cb89",
-                "sha256:b99b2607b6cd58396f363b448cbe71d3c35e28f03e442ab00806463439629c2c",
-                "sha256:cd47793f7bc9285a88c2b5551d3f16a2ddd005789614a34c5f4a598c2a162383",
-                "sha256:d6bf085f6f9ec6a1724c187083b37b58a8048f86036d42d21802ed5d1fae4853",
-                "sha256:da737ab273f4d60ae552f82ad83f7cbd0e173ca30ca20b160f708c92742ee212",
-                "sha256:eb84e7e5b07ff3725ab05977ac56d5eeb0c510795aeb48e8b691491be3c5745b"
+                "sha256:04766c4930c174b46fd72d450674612ab44cca977ebbcc2dde722c6933290107",
+                "sha256:0e2a3bceb0fd4e0cb17192ae506d5f082b309ffe5fc370a5667959c9b2f85fa3",
+                "sha256:0f01e63c34f0e1e2580cc0b24e86a5ccbbfa8830909a52ee17624c4193224cd9",
+                "sha256:12e4bad6bddd8546a2f9771485c7e3d2b546b458ae8ff79621214119ac244523",
+                "sha256:1f694e28c169655c50bb89a3fa07f3b854d71eb47f50783621de813979ba87f3",
+                "sha256:3d25dd8d688f7318dca6d8cd4f962a360ee40346c15893ae3b95c061cdbc4079",
+                "sha256:4b02b9c27fad2054932e89f39703646d0c543f21d3cc5b8e05434215121c28cd",
+                "sha256:9744350687459234867cbebfe9df8f35ef9e1538f3e729adbd8fde0761adb705",
+                "sha256:a0b49960110bc6ff5fead46013bcb8825d101026d466f3a4de3476defe0fb0dd",
+                "sha256:ae2b270f9a0b8822b98655cb3a59cdb1bd54a34807c6c56b76dd2e786c3b7db3",
+                "sha256:b37bb3bd35edf53125b0ff257822afa6962649995cbdfde2791ddb62b239f891",
+                "sha256:b532bcc2f008e96fd9241177ec580829dee817b090532f43e54074ecffdcd97f",
+                "sha256:b67a6c47ed963c709ed24566daa3f95a18f07d3831334da570c71da53d97d088",
+                "sha256:b943e71c2065ade6fef223358e56c167fc6ce31c50bc7a02dd5c17ee4338e8ac",
+                "sha256:ccc9ad2460eb5bee5642eaf75a0438d7f8887d484490d5117b98edd7f33118b7",
+                "sha256:d23e2aa9b969cf9c26edfb4b56307792b8b374202810bd949effd1c6e11ebd6d",
+                "sha256:eaa83729eab9c60884f362ada982d3a06beaa6cc8b084cf9f76cae7739481dfa",
+                "sha256:ee94fce8d003ac9fd206496f2707efe9eadcb278d94c271f129ab36aa7181344",
+                "sha256:f455efb7a98557412dc6f8e463c1faf1f1911ec2432059fa3e582b6000fc90e2",
+                "sha256:f46e0e024346e1474083c729d50de909974237c72daca05393ee32389dabe457",
+                "sha256:f54be399340aa602066adb63a86a6a5d4f395adfdd9da2b9a0162ea808c7b276",
+                "sha256:f784aad988f12c80aacfa5b381ec21fd3f38f851720f652b9f33facc5101cf4d"
             ],
-            "version": "==7.1.1"
+            "version": "==7.1.2"
         },
         "pony": {
             "hashes": [
@@ -271,29 +271,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b",
-                "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8",
-                "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3",
-                "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e",
-                "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683",
-                "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1",
-                "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142",
-                "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3",
-                "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468",
-                "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e",
-                "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3",
-                "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a",
-                "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f",
-                "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6",
-                "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156",
-                "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b",
-                "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db",
-                "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd",
-                "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a",
-                "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948",
-                "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"
+                "sha256:1386e75c9d1574f6aa2e4eb5355374c8e55f9aac97e224a8a5a6abded0f9c927",
+                "sha256:27ff7325b297fb6e5ebb70d10437592433601c423f5acf86e5bc1ee2919b9561",
+                "sha256:329ba35d711e3428db6b45a53b1b13a0a8ba07cbbcf10bbed291a7da45f106c3",
+                "sha256:3a9394197664e35566242686d84dfd264c07b20f93514e2e09d3c2b3ffdf78fe",
+                "sha256:51f17abbe973c7673a61863516bdc9c0ef467407a940f39501e786a07406699c",
+                "sha256:579ea215c81d18da550b62ff97ee187b99f1b135fd894a13451e00986a080cad",
+                "sha256:70c14743320a68c5dac7fc5a0f685be63bc2024b062fe2aaccc4acc3d01b14a1",
+                "sha256:7e61be8a2900897803c293247ef87366d5df86bf701083b6c43119c7c6c99108",
+                "sha256:8044d1c085d49673aadb3d7dc20ef5cb5b030c7a4fa253a593dda2eab3059929",
+                "sha256:89d76ce33d3266173f5be80bd4efcbd5196cafc34100fdab814f9b228dee0fa4",
+                "sha256:99568f00f7bf820c620f01721485cad230f3fb28f57d8fbf4a7967ec2e446994",
+                "sha256:a7c37f048ec3920783abab99f8f4036561a174f1314302ccfa4e9ad31cb00eb4",
+                "sha256:c2062c7d470751b648f1cacc3f54460aebfc261285f14bc6da49c6943bd48bdd",
+                "sha256:c9bce6e006fbe771a02bda468ec40ffccbf954803b470a0345ad39c603402577",
+                "sha256:ce367d21f33e23a84fb83a641b3834dd7dd8e9318ad8ff677fbfae5915a239f7",
+                "sha256:ce450ffbfec93821ab1fea94779a8440e10cf63819be6e176eb1973a6017aff5",
+                "sha256:ce5cc53aa9fbbf6712e92c7cf268274eaff30f6bd12a0754e8133d85a8fb0f5f",
+                "sha256:d466967ac8e45244b9dfe302bbe5e3337f8dc4dec8d7d10f5e950d83b140d33a",
+                "sha256:d881c2e657c51d89f02ae4c21d9adbef76b8325fe4d5cf0e9ad62f850f3a98fd",
+                "sha256:e565569fc28e3ba3e475ec344d87ed3cd8ba2d575335359749298a0899fe122e",
+                "sha256:ea55b80eb0d1c3f1d8d784264a6764f931e172480a2f1868f2536444c5f01e01"
             ],
-            "version": "==2020.4.4"
+            "version": "==2020.5.14"
         },
         "requests": {
             "hashes": [
@@ -318,10 +318,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:e914534802d7ffd233242b785229d5ba0766a7f487385e3f714446a07bf540ae",
-                "sha256:fcd71e08c0aee99aca1b73f45478549ee7e7fc006d51b37bec9e9def7dc22b69"
+                "sha256:1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55",
+                "sha256:a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232"
             ],
-            "version": "==2.0"
+            "version": "==2.0.1"
         },
         "unidecode": {
             "hashes": [
@@ -360,10 +360,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
-                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
+                "sha256:4c17cea3e592c21b6e222f673868961bad77e1f985cb1694ed077475a89229c1",
+                "sha256:d8506842a3faf734b81599c8b98dcc423de863adcc1999248480b18bd31a0f38"
             ],
-            "version": "==2.3.3"
+            "version": "==2.4.1"
         },
         "attrs": {
             "hashes": [
@@ -381,10 +381,10 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:cc8da25076a1fe56c3ac63671e2194458e0c4d9c7becfd52ca251650d517903c",
-                "sha256:e78e426105ac07026ba098f04de8abe9b6e3e98b5befbf89b51a5ef0a4292b03"
+                "sha256:2bce3d8fab545a6528c8fa5d9f9ae8ebc85a56da365c7f85180bfe96a35ef22f",
+                "sha256:3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b"
             ],
-            "version": "==3.1.4"
+            "version": "==3.1.5"
         },
         "certifi": {
             "hashes": [
@@ -444,20 +444,13 @@
             ],
             "version": "==0.16"
         },
-        "entrypoints": {
-            "hashes": [
-                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
-                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
-            ],
-            "version": "==0.3"
-        },
         "flake8": {
             "hashes": [
-                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
-                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
+                "sha256:6c1193b0c3f853ef763969238f6c81e9e63ace9d024518edc020d5f1d6d93195",
+                "sha256:ea6623797bf9a52f4c9577d780da0bb17d65f870213f7b5bcc9fca82540c31d5"
             ],
             "index": "pypi",
-            "version": "==3.7.9"
+            "version": "==3.8.1"
         },
         "idna": {
             "hashes": [
@@ -484,10 +477,10 @@
         },
         "keyring": {
             "hashes": [
-                "sha256:197fd5903901030ef7b82fe247f43cfed2c157a28e7747d1cfcf4bc5e699dd03",
-                "sha256:8179b1cdcdcbc221456b5b74e6b7cfa06f8dd9f239eb81892166d9223d82c5ba"
+                "sha256:3401234209015144a5d75701e71cb47239e552b0882313e9f51e8976f9e27843",
+                "sha256:c53e0e5ccde3ad34284a40ce7976b5b3a3d6de70344c3f8ee44364cc340976ec"
             ],
-            "version": "==21.2.0"
+            "version": "==21.2.1"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -524,10 +517,10 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
-                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+                "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be",
+                "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"
             ],
-            "version": "==8.2.0"
+            "version": "==8.3.0"
         },
         "mypy": {
             "hashes": [
@@ -586,17 +579,17 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "version": "==2.5.0"
+            "version": "==2.6.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
-                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "version": "==2.1.1"
+            "version": "==2.2.0"
         },
         "pygments": {
             "hashes": [
@@ -607,11 +600,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
-                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
+                "sha256:b95e31850f3af163c2283ed40432f053acbc8fc6eba6a069cb518d9dbf71848c",
+                "sha256:dd506acce0427e9e08fb87274bcaa953d38b50a58207170dbf5b36cf3e16957b"
             ],
             "index": "pypi",
-            "version": "==2.4.4"
+            "version": "==2.5.2"
         },
         "pyparsing": {
             "hashes": [
@@ -622,11 +615,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
+                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
             ],
             "index": "pypi",
-            "version": "==5.4.1"
+            "version": "==5.4.2"
         },
         "python-memcached": {
             "hashes": [
@@ -638,10 +631,10 @@
         },
         "readme-renderer": {
             "hashes": [
-                "sha256:1b6d8dd1673a0b293766b4106af766b6eff3654605f9c4f239e65de6076bc222",
-                "sha256:e67d64242f0174a63c3b727801a2fff4c1f38ebe5d71d95ff7ece081945a6cd4"
+                "sha256:cbe9db71defedd2428a1589cdc545f9bd98e59297449f69d721ef8f1cfced68d",
+                "sha256:cc4957a803106e820d05d14f71033092537a22daa4f406dfbdd61177e0936376"
             ],
-            "version": "==25.0"
+            "version": "==26.0"
         },
         "requests": {
             "hashes": [
@@ -664,12 +657,19 @@
             ],
             "version": "==1.14.0"
         },
+        "toml": {
+            "hashes": [
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+            ],
+            "version": "==0.10.1"
+        },
         "tqdm": {
             "hashes": [
-                "sha256:00339634a22c10a7a22476ee946bbde2dbe48d042ded784e4d88e0236eca5d81",
-                "sha256:ea9e3fd6bd9a37e8783d75bfc4c1faf3c6813da6bd1c3e776488b41ec683af94"
+                "sha256:4733c4a10d0f2a4d098d801464bdaf5240c7dadd2a7fde4ee93b0a0efd9fb25e",
+                "sha256:acdafb20f51637ca3954150d0405ff1a7edde0ff19e38fb99a80a66210d2a28f"
             ],
-            "version": "==4.45.0"
+            "version": "==4.46.0"
         },
         "twine": {
             "hashes": [
@@ -737,9 +737,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
-            "version": "==1.11.2"
+            "version": "==1.12.1"
         },
         "zipp": {
             "hashes": [

--- a/publ/category.py
+++ b/publ/category.py
@@ -37,6 +37,11 @@ def load_metafile(filepath):
     return None
 
 
+def search_path(category:str) -> str:
+    """ Return the file search path for a named category """
+    return os.path.join(config.content_folder, category)
+
+
 class Category(caching.Memoizable):
     """ Wrapper for category information """
     # pylint: disable=too-few-public-methods,too-many-instance-attributes
@@ -193,8 +198,8 @@ class Category(caching.Memoizable):
 
     @cached_property
     def search_path(self) -> str:
-        """ Get the image search path for the category """
-        return os.path.join(config.content_folder, self.path)
+        """ Get the file search path for this category """
+        return search_path(self.path)
 
     @cached_property
     def breadcrumb(self) -> typing.List["Category"]:

--- a/publ/category.py
+++ b/publ/category.py
@@ -37,7 +37,7 @@ def load_metafile(filepath):
     return None
 
 
-def search_path(category:str) -> str:
+def search_path(category: str) -> str:
     """ Return the file search path for a named category """
     return os.path.join(config.content_folder, category)
 

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -528,8 +528,9 @@ class Entry(caching.Memoizable):
         from .view import View
 
         def _get_attachments(order=None, **kwargs) -> str:
-            query = queries.build_query(kwargs)
-            query = query.filter(lambda e: self._record in e.attached)
+            query = queries.build_query({**kwargs,
+                'attachments': self._record
+                })
             if order:
                 query = query.order_by(*queries.ORDER_BY[order])
             return [Entry(e) for e in query]
@@ -541,8 +542,9 @@ class Entry(caching.Memoizable):
         """ Get all the entries that have attached this one """
 
         def _get_attached(order=None, **kwargs) -> str:
-            query = queries.build_query(kwargs)
-            query = query.filter(lambda e: self._record in e.attachments)
+            query = queries.build_query({**kwargs,
+                'attached': self._record
+                })
             if order:
                 query = query.order_by(*queries.ORDER_BY[order])
             return [Entry(e) for e in query]

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -525,12 +525,11 @@ class Entry(caching.Memoizable):
     def attachments(self) -> typing.Callable[..., typing.List]:
         """ Returns a view of entries that are attached to this one. Takes the
         standard view arguments. """
-        from .view import View
 
-        def _get_attachments(order=None, **kwargs) -> str:
+        def _get_attachments(order=None, **kwargs) -> typing.List:
             query = queries.build_query({**kwargs,
-                'attachments': self._record
-                })
+                                         'attachments': self._record
+                                         })
             if order:
                 query = query.order_by(*queries.ORDER_BY[order])
             return [Entry(e) for e in query]
@@ -541,10 +540,10 @@ class Entry(caching.Memoizable):
     def attached(self) -> typing.Callable[..., typing.List]:
         """ Get all the entries that have attached this one """
 
-        def _get_attached(order=None, **kwargs) -> str:
+        def _get_attached(order=None, **kwargs) -> typing.List:
             query = queries.build_query({**kwargs,
-                'attached': self._record
-                })
+                                         'attached': self._record
+                                         })
             if order:
                 query = query.order_by(*queries.ORDER_BY[order])
             return [Entry(e) for e in query]

--- a/publ/index.py
+++ b/publ/index.py
@@ -168,7 +168,7 @@ def set_fingerprint(fullpath, fingerprint=None):
         if record and record.fingerprint != fingerprint:
             record.set(fingerprint=fingerprint,
                        file_mtime=os.stat(fullpath).st_mtime)
-        else:
+        elif not record:
             record = model.FileFingerprint(
                 file_path=fullpath,
                 fingerprint=fingerprint,

--- a/publ/links.py
+++ b/publ/links.py
@@ -26,9 +26,9 @@ def resolve(path: str, search_path: typing.Tuple[str, ...], absolute: bool = Fal
     path, sep, anchor = path.partition('#')
 
     # Resolve entries
-    found = _find_entry(path, search_path)
+    found = find_entry(path, search_path)
     if found:
-        return found.permalink(absolute=absolute) + sep + anchor
+        return entry.Entry(found).permalink(absolute=absolute) + sep + anchor
 
     # Resolve images and assets
     img_path, img_args, _ = image.parse_image_spec(path)
@@ -43,7 +43,7 @@ def resolve(path: str, search_path: typing.Tuple[str, ...], absolute: bool = Fal
     return path + sep + anchor
 
 
-def _find_entry(rel_path: str, search_path: typing.Tuple[str, ...]):
+def find_entry(rel_path: str, search_path: typing.Tuple[str, ...]) -> typing.Optional[model.Entry]:
     """ Find an entry by relative path. Arguments:
 
     rel_path -- the entry's filename (or entry ID)
@@ -56,7 +56,7 @@ def _find_entry(rel_path: str, search_path: typing.Tuple[str, ...]):
         entry_id = int(rel_path)
         record = model.Entry.get(id=entry_id)
         if record:
-            return entry.Entry(record)
+            return record
     except ValueError:
         pass
 
@@ -68,5 +68,5 @@ def _find_entry(rel_path: str, search_path: typing.Tuple[str, ...]):
         abspath = os.path.normpath(os.path.join(where, rel_path))
         record = model.Entry.get(file_path=abspath)
         if record:
-            return entry.Entry(record)
+            return record
     return None

--- a/publ/model.py
+++ b/publ/model.py
@@ -18,7 +18,7 @@ DbEntity: orm.core.Entity = db.Entity
 LOGGER = logging.getLogger(__name__)
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 
 class GlobalConfig(DbEntity):
@@ -90,6 +90,9 @@ class Entry(DbEntity):
 
     auth = orm.Set("EntryAuth")
     auth_log = orm.Set("AuthLog")
+
+    attachments = orm.Set("Entry", reverse="attached")
+    attached = orm.Set("Entry", reverse="attachments")
 
     canonical_path = orm.Optional(str)
 

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -38,6 +38,7 @@ REVERSE_ORDER_BY = {
     'title': (orm.desc(model.Entry.sort_title), orm.desc(model.Entry.id))
 }
 
+
 def where_entry_visible(query, date=None):
     """ Generate a where clause for currently-visible entries
 
@@ -200,21 +201,26 @@ def where_entry_date(query, datespec):
                         e.local_date <= end_date.naive
                         )
 
+
 def where_entry_attachments(query, entry):
     """ Where clause for entries which are attachments of the specified one. """
     return query.filter(lambda e: e in entry.attachments)
+
 
 def where_entry_attached(query, entry):
     """ Where clause for entries which this one is attached onto. """
     return query.filter(lambda e: e in entry.attached)
 
+
 def where_entry_has_attachments(query, val):
     """ Where clause for entries which have attachments """
     return query.filter(lambda e: val == orm.exists(e.attachments))
 
+
 def where_entry_is_attached(query, val):
     """ Where clause for entries which are attached """
     return query.filter(lambda e: val == orm.exists(e.attached))
+
 
 def get_entry(entry):
     """ Helper function to get an entry by ID or by object """

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -25,6 +25,19 @@ class FilterCombiner(Enum):
     NOT = 2     # synonym for NONE
 
 
+# Ordering queries for different sort orders
+ORDER_BY = {
+    'newest': (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id)),
+    'oldest': (model.Entry.local_date, model.Entry.id),
+    'title': (model.Entry.sort_title, model.Entry.id)
+}
+
+REVERSE_ORDER_BY = {
+    'newest': (model.Entry.local_date, model.Entry.id),
+    'oldest': (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id)),
+    'title': (orm.desc(model.Entry.sort_title), orm.desc(model.Entry.id))
+}
+
 def where_entry_visible(query, date=None):
     """ Generate a where clause for currently-visible entries
 

--- a/publ/view.py
+++ b/publ/view.py
@@ -6,10 +6,9 @@ import typing
 
 import arrow
 import flask
-from pony import orm
 from werkzeug.utils import cached_property
 
-from . import caching, model, queries, tokens, user, utils
+from . import caching, queries, tokens, user, utils
 from .entry import Entry
 
 ViewSpec = typing.Dict[str, typing.Any]  # pylint:disable=invalid-name
@@ -393,9 +392,9 @@ class View(caching.Memoizable):
 
         base_query = queries.build_query(base)
         oldest_neighbor = base_query.filter(lambda e: e.local_date < start_date.datetime)\
-        .order_by(*queries.ORDER_BY['newest']).first()
+            .order_by(*queries.ORDER_BY['newest']).first()
         newest_neighbor = base_query.filter(lambda e: e.local_date > end_date.datetime)\
-        .order_by(*queries.ORDER_BY['oldest']).first()
+            .order_by(*queries.ORDER_BY['oldest']).first()
 
         older_view: typing.Optional['View'] = None
         newer_view: typing.Optional['View'] = None

--- a/publ/view.py
+++ b/publ/view.py
@@ -28,20 +28,6 @@ PAGINATION_PRIORITY = ['date', 'count']
 # All spec keys that indicate a pagination
 PAGINATION_SPECS = OFFSET_PRIORITY + PAGINATION_PRIORITY
 
-#: Ordering queries for different sort orders
-ORDER_BY = {
-    'newest': (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id)),
-    'oldest': (model.Entry.local_date, model.Entry.id),
-    'title': (model.Entry.sort_title, model.Entry.id)
-}
-
-REVERSE_ORDER_BY = {
-    'newest': (model.Entry.local_date, model.Entry.id),
-    'oldest': (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id)),
-    'title': (orm.desc(model.Entry.sort_title), orm.desc(model.Entry.id))
-}
-
-
 SPAN_FORMATS = {
     'day': 'YYYY/MM/DD',
     'week': 'YYYY/MM/DD',
@@ -94,7 +80,7 @@ class View(caching.Memoizable):
                 self.spec['last'] = self.spec['start']
 
         self._entries = queries.build_query(
-            spec).order_by(*ORDER_BY[self._order_by])
+            spec).order_by(*queries.ORDER_BY[self._order_by])
 
         if self.spec.get('date') is not None:
             _, self.type, _ = utils.parse_date(self.spec['date'])
@@ -406,10 +392,10 @@ class View(caching.Memoizable):
         start_date, end_date = date.span(interval)
 
         base_query = queries.build_query(base)
-        oldest_neighbor = base_query.filter(
-            lambda e: e.local_date < start_date.datetime).order_by(*ORDER_BY['newest']).first()
-        newest_neighbor = base_query.filter(
-            lambda e: e.local_date > end_date.datetime).order_by(*ORDER_BY['oldest']).first()
+        oldest_neighbor = base_query.filter(lambda e: e.local_date < start_date.datetime)\
+        .order_by(*queries.ORDER_BY['newest']).first()
+        newest_neighbor = base_query.filter(lambda e: e.local_date > end_date.datetime)\
+        .order_by(*queries.ORDER_BY['oldest']).first()
 
         older_view: typing.Optional['View'] = None
         newer_view: typing.Optional['View'] = None

--- a/publ/view.py
+++ b/publ/view.py
@@ -469,6 +469,9 @@ class View(caching.Memoizable):
     def __call__(self, **restrict):
         return View({**self.spec, **restrict})
 
+    def __iter__(self):
+        return self.entries().__iter__()
+
     def tag_add(self, *tags: utils.ListLike[str]) -> 'View':
         """ Return a view with the specified tags added """
         return View({**self.spec, 'tag': self.tags | set(tags)})

--- a/tests/content/attach/another.md
+++ b/tests/content/attach/another.md
@@ -1,0 +1,7 @@
+Title: Another entry
+Attach: supplement 2.md
+Date: 2020-05-17 18:21:39-07:00
+Entry-ID: 1708
+UUID: e82e4e90-3464-5e91-9661-f5abf3d3dfb5
+
+This is another entry that also attaches the second supplement.

--- a/tests/content/attach/main.md
+++ b/tests/content/attach/main.md
@@ -1,0 +1,12 @@
+Title: Main entry
+Date: 2020-05-17 16:37:14-07:00
+UUID: 65e871c6-0c4f-5dca-98a0-765c329d85f9
+Attach: supplement 1.md
+Attach: 1349
+Entry-ID: 1208
+
+This is the main entry that will contain the other entry. This is the main text.
+
+.....
+
+This is the body text.

--- a/tests/content/attach/supplement 1.md
+++ b/tests/content/attach/supplement 1.md
@@ -4,5 +4,6 @@ Entry-Type: supplement
 Date: 2020-05-17 16:37:26-07:00
 UUID: 226f8146-e343-5325-960d-a49400f6cbfe
 Entry-ID: 1416
+Sort-Title: 1
 
 This is the first supplement.

--- a/tests/content/attach/supplement 1.md
+++ b/tests/content/attach/supplement 1.md
@@ -1,0 +1,8 @@
+Title: First Supplement
+Entry-Link: 1208
+Entry-Type: supplement
+Date: 2020-05-17 16:37:26-07:00
+UUID: 226f8146-e343-5325-960d-a49400f6cbfe
+Entry-ID: 1416
+
+This is the first supplement.

--- a/tests/content/attach/supplement 2.md
+++ b/tests/content/attach/supplement 2.md
@@ -3,5 +3,6 @@ Entry-Type: supplement
 Date: 2020-05-17 16:37:29-07:00
 UUID: 10aeb57c-94e3-5fa1-911e-dde286693058
 Entry-ID: 1349
+Sort-Title: 2
 
 This is the second supplement.

--- a/tests/content/attach/supplement 2.md
+++ b/tests/content/attach/supplement 2.md
@@ -1,0 +1,7 @@
+Title: Supplement the 2nd
+Entry-Type: supplement
+Date: 2020-05-17 16:37:29-07:00
+UUID: 10aeb57c-94e3-5fa1-911e-dde286693058
+Entry-ID: 1349
+
+This is the second supplement.

--- a/tests/templates/_entry.html
+++ b/tests/templates/_entry.html
@@ -65,13 +65,13 @@
             {% block entrybody scoped %}
             {{entry.body(footnotes_class='gronk',heading_link_class='permalink')}}
             {% endblock %}
-            {% if entry.more %}
-            <div id="more">
-                {% block entrymore scoped %}
-                {{entry.more(footnotes_class='plonk',heading_link_class='permalink')}}
-                {% endblock %}
-            </div>
-            {% endif %}
+            {% block entrymore scoped %}
+                {% if entry.more %}
+                <div id="more">
+                    {{entry.more(footnotes_class='plonk',heading_link_class='permalink')}}
+                </div>
+                {% endif %}
+            {% endblock %}
             {% if entry.footnotes %}
             <div id="footnotes">
                 <h2>Footnotes</h2>

--- a/tests/templates/attach/entry.html
+++ b/tests/templates/attach/entry.html
@@ -2,15 +2,17 @@
 
 {% block entrybody scoped %}
 {% if entry.attached %}
-<p>see also: {{entry.attached}}</p>
+<p>see also: {% for attached in entry.attached %}
+    <a href="{{attached.link}}">{{attached.title}}</a>
+{% endfor %}</p>
 {% endif %}
 {{ super() }}
 {% endblock %}
 
 {% block entrymore scoped %}
 {{ super() }}
-{% for attach in entry.attachments %}
-<h3>{{attach.title}}</h3>
+{% for attach in entry.attachments(order='title') %}
+<h3><a href="{{attach.link}}">{{attach.title}}</a></h3>
 
 {{attach.body}}
 {{attach.more}}

--- a/tests/templates/attach/entry.html
+++ b/tests/templates/attach/entry.html
@@ -1,0 +1,19 @@
+{% extends '/entry.html' %}
+
+{% block entrybody scoped %}
+{% if entry.attached %}
+<p>see also: {{entry.attached}}</p>
+{% endif %}
+{{ super() }}
+{% endblock %}
+
+{% block entrymore scoped %}
+{{ super() }}
+{% for attach in entry.attachments %}
+<h3>{{attach.title}}</h3>
+
+{{attach.body}}
+{{attach.more}}
+</h3>
+{% endfor %}
+{% endblock %}

--- a/tests/templates/attach/entry.html
+++ b/tests/templates/attach/entry.html
@@ -18,4 +18,19 @@
 {{attach.more}}
 </h3>
 {% endfor %}
+
+<p>Attachments of this entry via get_view:</p>
+<ul>
+{% for attach in get_view(attachments=entry) %}
+<li>{{attach.title}}</li>
+{% endfor %}
+</ul>
+
+<p>What this entry is attached to via get_view:</p>
+<ul>
+{% for attach in get_view(attached=entry) %}
+<li>{{attach.title}}</li>
+{% endfor %}
+</ul>
+
 {% endblock %}

--- a/tests/templates/attach/index.html
+++ b/tests/templates/attach/index.html
@@ -1,0 +1,6 @@
+{% extends '/index.html' %}
+
+{% block body scoped %}
+<p>Attachment count: {{entry.attachments|length}} {{entry.attachments}}</p>
+{{super()}}
+{% endblock %}

--- a/tests/templates/attach/index.html
+++ b/tests/templates/attach/index.html
@@ -1,6 +1,25 @@
 {% extends '/index.html' %}
 
 {% block body scoped %}
-<p>Attachment count: {{entry.attachments|length}} {{entry.attachments}}</p>
+<p>Attachment count: {{entry.attachments|length}}</p>
 {{super()}}
+{% endblock %}
+
+{% block entries scoped %}
+{{super()}}
+
+<h2>Entries with attachments</h2>
+<ul>
+    {% for entry in content(is_attached=None,has_attachments=True) %}
+    <li><a href="{{entry.link}}">{{entry.title}}</a></li>
+    {% endfor %}
+</ul>
+
+<h2>Entries which are attached</h2>
+<ul>
+    {% for entry in content(has_attachments=None,is_attached=True) %}
+    <li><a href="{{entry.link}}">{{entry.title}}</a></li>
+    {% endfor %}
+</ul>
+
 {% endblock %}

--- a/tests/templates/index.html
+++ b/tests/templates/index.html
@@ -44,7 +44,7 @@
 
 {% block content %}
 <div id="content">
-    {% set content = view(entry_type_not=['sidebar','supplement'],count=20) %}
+    {% set content = view(entry_type_not=['sidebar'],is_attached=False,count=20) %}
 
     <div class="nav">
         {% if content.previous %}
@@ -65,7 +65,7 @@
         </div>
         {% endif %}
 
-        {% for entry in content.entries %}
+        {% for entry in content %}
 
         <article class="h-entry entry">
         {% block entry scoped %}

--- a/tests/templates/index.html
+++ b/tests/templates/index.html
@@ -44,7 +44,7 @@
 
 {% block content %}
 <div id="content">
-    {% set content = view(entry_type_not='sidebar',count=20) %}
+    {% set content = view(entry_type_not=['sidebar','supplement'],count=20) %}
 
     <div class="nav">
         {% if content.previous %}

--- a/tests/test_html_entry.py
+++ b/tests/test_html_entry.py
@@ -16,7 +16,8 @@ modified in it, and shouldn't require an
 <a href="https://flask.palletsprojects.com/en/1.1.x/appcontext/">application
 context</a> to function.</p>
 
-<img src="//example.com/some-image.png">
+<img src="//example.com/some-image.png" width="500">
+<img data-qwer="poiu" width="yes" height="no">
 
 <br/><br/>
 
@@ -44,6 +45,16 @@ def test_process_attr_rewrites():
             '<div data-something="/bleh/something" />'
         assert process('<div $data-something="@something" />', {'absolute': True}, ()) == \
             '<div data-something="https://foo.bar/bleh/something" />'
+
+
+def test_image_args():
+    import flask
+    from publ.html_entry import process
+
+    app = flask.Flask(__name__, static_folder="bleh")
+    with app.test_request_context("https://foo.bar/baz"):
+        assert process('<img src="//example.com/image.png{500}">', {}, ()) == \
+            '<img src="//example.com/image.png" width="500">'
 
 
 def test_process_strip_html():


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Allows attaching entries to other entries; fixes #355 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Adds a new header to entries, `Attach`, which associates another entry as an attachment to this one.

Adds some entry methods, `attachments` and `attached`, which list the attachments of this entry, and other entries this entry is attached to, respectively. These also take standard view parameters.

Adds four view parameters:

* `has_attachments`: boolean, restricts to entries with attachments
* `is_attached`: boolean, restricts to entries which have been attached
* `attachments`: entry, restricts to entries which are attachments of the specified one
* `attached`: entry, restricts to entries which the specified one is attached to

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Tests in the `attach/` directory

## Got a site to show off?

<!-- If so, link to it here! -->
