### PR TITLE
Fix the logic for reindexing around ID changes

### DIFF
--- a/publ/model.py
+++ b/publ/model.py
@@ -18,7 +18,7 @@ DbEntity: orm.core.Entity = db.Entity
 LOGGER = logging.getLogger(__name__)
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
 
 
 class GlobalConfig(DbEntity):
@@ -64,7 +64,7 @@ class FileFingerprint(DbEntity):
 
 class Entry(DbEntity):
     """ Indexed entry """
-    file_path = orm.Required(str, index=True)
+    file_path = orm.Required(str, unique=True)
     category = orm.Optional(str)
     status = orm.Required(int)
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -84,8 +84,8 @@ def image_function(template=None,
         # this too
         path += (category.search_path,)
     if template is not None:
-        path += os.path.join(config.content_folder,
-                             os.path.dirname(template.filename)),
+        path += (os.path.join(config.content_folder,
+                              os.path.dirname(template.filename)),)
 
     return lambda filename: image.get_image(filename, path)
 
@@ -464,7 +464,7 @@ def render_entry_record(record: model.Entry, category: str, template: typing.Opt
         current_id: typing.Optional[int] = int(entry_obj.get('Entry-ID'))  # type:ignore
     except (KeyError, TypeError, ValueError) as err:
         LOGGER.debug("Error checking entry ID: %s", err)
-        current_id = None
+        current_id = record.id
     if current_id != record.id:
         LOGGER.debug("entry %s says it has id %d, index says %d",
                      entry_obj.file_path, current_id, record.id)
@@ -472,7 +472,7 @@ def render_entry_record(record: model.Entry, category: str, template: typing.Opt
         from .entry import scan_file
         scan_file(entry_obj.file_path, None, True)
 
-        return redirect(url_for('entry', entry_id=record.id))
+        return redirect(url_for('entry', entry_id=current_id))
 
     entry_template = (template
                       or entry_obj.get('Entry-Template')

--- a/tests/content/entry_id/collision 1.md
+++ b/tests/content/entry_id/collision 1.md
@@ -1,0 +1,6 @@
+Title: collision 1
+Date: 2020-05-26 23:26:35-07:00
+Entry-ID: 2100
+UUID: a3fc6a9f-0113-5cde-9c5d-25fb6e1dbc34
+
+test of collisions

--- a/tests/content/entry_id/collision 2.md
+++ b/tests/content/entry_id/collision 2.md
@@ -1,0 +1,6 @@
+Title: collision 2
+Date: 2020-05-26 23:26:45-07:00
+Entry-ID: 2420
+UUID: e77ac09a-cfb1-52e4-af44-9f68ab7767b6
+
+test of collisions

--- a/tests/content/entry_id/collision 3.md
+++ b/tests/content/entry_id/collision 3.md
@@ -1,0 +1,6 @@
+Title: collision 3
+Entry-ID: 12345
+Date: 2020-05-26 23:27:03-07:00
+UUID: 9742fd1c-052f-5caf-868e-a94540ca52ae
+
+test of collisions

--- a/tests/content/entry_id/renumber.md
+++ b/tests/content/entry_id/renumber.md
@@ -1,0 +1,6 @@
+Title: Renumber
+Date: 2020-05-26 23:34:03-07:00
+Entry-ID: 1974
+UUID: 66984b68-480a-5817-ab48-f838eda4e0e3
+
+What happens when we change the entry ID on an entry?


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Better-handle reindexing when an entry ID changes; fixes #381 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
1. Restores the uniqueness constraint to `model.Entry.file_path`
2. When indexing a file, removes other database rows which reference the file path but with a different entry ID
3. Forwards requests for an updated entry ID based on the updated ID and not the (stale) database record

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Created multiple new entries with the same ID; verified that they resolve the collision appropriately.

Created entry, indexed it, paused the indexer, changed the ID in the file, reloaded index page

Paused the indexer, changed the ID in the file, reloaded entry page with old ID

Paused the indexer, changed the ID in the file, loaded entry page with new ID

Paused the indexer, renamed a file, reloaded index page

Paused the indexer, renamed a file, reloaded entry page


## Got a site to show off?

<!-- If so, link to it here! -->
