### PR TITLE
Cache the WWW-Authenticate response

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -74,7 +74,7 @@ class Publ(flask.Flask):
         # pylint:disable=too-many-branches,too-many-statements
 
         if Publ._instance and Publ._instance is not self:
-            raise RuntimeError("Only one Publ app can run at a time")
+            LOGGER.warning("Only one Publ app can run at a time (%s,%s)", Publ._instance, self)
         Publ._instance = self
 
         config.setup(cfg)  # https://github.com/PlaidWeb/Publ/issues/113

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -111,7 +111,7 @@ def inject_auth_headers(response):
     """ If the request triggered a need to authenticate, add the appropriate
     headers. """
 
-    if flask.g.get('needs_token'):
+    if flask.g.stash.get('needs_token'):
         header = 'Bearer, realm="posts", scope="read"'
         if 'token_error' in flask.g:
             header += ', error="invalid_token", error_description="{msg}"'.format(
@@ -127,5 +127,5 @@ def request(user):
     """ Called whenever an authenticated access fails; marks authentication
     as being upgradeable. """
     if not user:
-        flask.g.needs_token = True
+        flask.g.stash['needs_token'] = True
     return user


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Caches the authorization header output as part of the top-level template render. Fixes #386 

## Detailed description

Moves render-side stashing into `flask.g.stash`, and makes the stash output part of what gets cached. This was easier in the long run than adding more and more things to cache, and safer than just caching all the things.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
```sh
# in one terminal
TEST_CACHING=simple ./runTests.sh fast

# in other terminal
curl -H 'Authorization: Bearer '$(FLASK_APP=tests/app.py pipenv run flask publ token test:friend2) http://localhost:5000/auth/
# changing the token and retrieving the page multiple times to test the caching
```

## Got a site to show off?

<!-- If so, link to it here! -->
