### PR TITLE
Rework flask.g stashing to add proper object pooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build: preflight pylint flake8
 
 .PHONY: clean
 clean:
-	rm -rf build dist
+	rm -rf build dist __pycache__
 
 .PHONY: upload
 upload: clean test build

--- a/publ/category.py
+++ b/publ/category.py
@@ -46,7 +46,7 @@ class Category(caching.Memoizable):
     """ Wrapper for category information """
     # pylint: disable=too-few-public-methods,too-many-instance-attributes
 
-    __hash__ = caching.Memoizable.__hash__
+    __hash__ = caching.Memoizable.__hash__  # type:ignore
 
     @staticmethod
     @utils.stash

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -35,7 +35,7 @@ class Entry(caching.Memoizable):
 
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
 
-    __hash__ = caching.Memoizable.__hash__
+    __hash__ = caching.Memoizable.__hash__  # type:ignore
 
     @staticmethod
     @utils.stash

--- a/publ/index.py
+++ b/publ/index.py
@@ -159,9 +159,9 @@ class Indexer:
 def last_indexed() -> typing.Optional[str]:
     """ information about the most recently indexed file, for cache-busting
     purposes """
-    last_indexed = current_app.indexer.last_indexed
-    if last_indexed:
-        return get_last_fingerprint(last_indexed)
+    ref = current_app.indexer.last_indexed
+    if ref:
+        return get_last_fingerprint(ref)
     return None
 
 

--- a/publ/links.py
+++ b/publ/links.py
@@ -28,7 +28,7 @@ def resolve(path: str, search_path: typing.Tuple[str, ...], absolute: bool = Fal
     # Resolve entries
     found = find_entry(path, search_path)
     if found:
-        return entry.Entry(found).permalink(absolute=absolute) + sep + anchor
+        return entry.Entry.load(found).permalink(absolute=absolute) + sep + anchor
 
     # Resolve images and assets
     img_path, img_args, _ = image.parse_image_spec(path)

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -96,7 +96,7 @@ def render_publ_template(template: Template, **kwargs) -> typing.Tuple[str, str]
     Returns tuple of (rendered text, etag)
     """
     @cache.memoize(unless=caching.do_not_cache)
-    def do_render(template: Template, **kwargs) -> typing.Tuple[str, str]:
+    def do_render(template: Template, **kwargs) -> typing.Tuple[str, str, typing.Dict]:
         LOGGER.debug("Rendering template %s with args %s and kwargs %s; caching=%s",
                      template, request.args, kwargs, not caching.do_not_cache)
 
@@ -126,12 +126,12 @@ def render_publ_template(template: Template, **kwargs) -> typing.Tuple[str, str]
         flask.g.stash = {}
         text, etag, flask.g.stash = do_render(
             template,
-                         user=user.get_active(),
-                         _url=request.url,
-                         _index_time=index.last_indexed(),
-                         _latest=latest_entry(),
-                         _publ_version=__version__.__version__,
-                         **kwargs)
+            user=user.get_active(),
+            _url=request.url,
+            _index_time=index.last_indexed(),
+            _latest=latest_entry(),
+            _publ_version=__version__.__version__,
+            **kwargs)
         return text, etag
     except queries.InvalidQueryError as err:
         raise http_error.BadRequest(str(err))
@@ -173,7 +173,7 @@ def render_error(category, error_message, error_codes,
     if template:
         return render_publ_template(
             template,
-            category=Category(category),
+            category=Category.load(category),
             error={'code': error_code, 'message': error_message},
             exception=exception)[0], error_code, headers
 
@@ -281,7 +281,7 @@ def render_category_path(category: str, template: typing.Optional[str]):
             raise http_error.NotFound("No such category")
 
     if not template:
-        template = Category(category).get('Index-Template') or 'index'
+        template = Category.load(category).get('Index-Template') or 'index'
 
     tmpl = map_template(category, template)
 
@@ -300,11 +300,11 @@ def render_category_path(category: str, template: typing.Optional[str]):
 
     view_spec = view.parse_view_spec(request.args)
     view_spec['category'] = category
-    view_obj = view.View(view_spec)
+    view_obj = view.View.load(view_spec)
 
     rendered, etag = render_publ_template(
         tmpl,
-        category=Category(category),
+        category=Category.load(category),
         view=view_obj)
 
     if request.if_none_match.contains(etag):
@@ -344,7 +344,9 @@ def handle_unauthorized(cur_user, category='', **kwargs):
                 "User {name} does not have access".format(name=cur_user.name))
 
         # Render the category's unauthorized template
-        return render_publ_template(tmpl, category=Category(category), **kwargs)[0], 403, NO_CACHE
+        return render_publ_template(tmpl,
+                                    category=Category.load(category),
+                                    **kwargs)[0], 403, NO_CACHE
 
     # User is not already logged in, so present a login page
     raise http_error.Unauthorized()
@@ -360,7 +362,7 @@ def _check_authorization(record, category):
 
         if not authorized:
             return handle_unauthorized(cur_user,
-                                       entry=Entry(record),
+                                       entry=Entry.load(record),
                                        category=category)
     return None
 
@@ -460,7 +462,7 @@ def render_entry_record(record: model.Entry, category: str, template: typing.Opt
         return redirect(record.redirect_url)
 
     # Get the viewable entry
-    entry_obj = Entry(record)
+    entry_obj = Entry.load(record)
 
     # does the entry-id header mismatch? If so the old one is invalid
     try:
@@ -479,7 +481,7 @@ def render_entry_record(record: model.Entry, category: str, template: typing.Opt
 
     entry_template = (template
                       or entry_obj.get('Entry-Template')
-                      or Category(category).get('Entry-Template')
+                      or Category.load(category).get('Entry-Template')
                       or 'entry')
 
     tmpl = map_template(category, entry_template)
@@ -489,7 +491,7 @@ def render_entry_record(record: model.Entry, category: str, template: typing.Opt
     rendered, etag = render_publ_template(
         tmpl,
         entry=entry_obj,
-        category=Category(category))
+        category=Category.load(category))
 
     if request.if_none_match.contains(etag):
         return 'Not modified', 304

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -112,6 +112,7 @@ def render_publ_template(template: Template, **kwargs) -> typing.Tuple[str, str]
         text = template.render(**args)
         return text, caching.get_etag(text), flask.g.stash
 
+    @orm.db_session
     def latest_entry():
         # Cache-busting query based on most recently-visible entry
         cb_query = queries.build_query({})

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -102,7 +102,6 @@ def parse_token(token: str) -> typing.Dict[str, str]:
         return signer().loads(token, max_age=config.max_token_age)
     except itsdangerous.BadData as error:
         LOGGER.error("Got token parse error: %s", error)
-        flask.g.user = None
         flask.g.token_error = error.message
         raise http_error.Unauthorized(error.message)
 
@@ -111,7 +110,7 @@ def inject_auth_headers(response):
     """ If the request triggered a need to authenticate, add the appropriate
     headers. """
 
-    if flask.g.stash.get('needs_token'):
+    if 'stash' in flask.g and flask.g.stash.get('needs_token'):
         header = 'Bearer, realm="posts", scope="read"'
         if 'token_error' in flask.g:
             header += ', error="invalid_token", error_description="{msg}"'.format(

--- a/publ/user.py
+++ b/publ/user.py
@@ -110,7 +110,7 @@ class User(caching.Memoizable):
         return bool(config.admin_group and config.admin_group in self.groups)
 
 
-@utils.stash('user')
+@utils.stash
 def get_active() -> typing.Optional[User]:
     """ Get the active user """
     if 'Authorization' in flask.request.headers:

--- a/publ/view.py
+++ b/publ/view.py
@@ -39,7 +39,7 @@ class View(caching.Memoizable):
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """ A view of entries """
 
-    __hash__ = caching.Memoizable.__hash__
+    __hash__ = caching.Memoizable.__hash__  # type:ignore
 
     @staticmethod
     @utils.stash


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Improve the way we stash things on `flask.g`, and add object pooling for Entry, View, and Category. Fixes #387 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Now Entry, View, and Category objects get pooled for the life of the transaction. On particularly egregious views this speeds up performance around 15%!

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
Probably breaks external content-management scripts that are doing things they shouldn't be doing anyway (proper stable public API? what's that?)

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
