### PR TITLE
Get rid of global config

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -13,7 +13,8 @@ from pony import orm
 from werkzeug.utils import cached_property
 
 from . import entry  # pylint: disable=cyclic-import
-from . import caching, config, markdown, model, path_alias, queries, utils
+from . import caching, markdown, model, path_alias, queries, utils
+from .config import config
 
 LOGGER = logging.getLogger(__name__)
 

--- a/publ/cli.py
+++ b/publ/cli.py
@@ -6,7 +6,7 @@ import time
 import click
 from flask.cli import AppGroup, with_appcontext
 
-from . import config
+from .config import config
 
 publ_cli = AppGroup('publ', short_help="Publ-specific commands")  # pylint:disable=invalid-name
 

--- a/publ/config.py
+++ b/publ/config.py
@@ -1,61 +1,77 @@
 # config.py
 """ configuration container for Publ """
 
+import logging
 import os
-import sys
 import typing
 
+import werkzeug.local
 from dateutil import tz
+from flask import current_app
 
-# pylint: disable=invalid-name
-
-database_config = {
-    'provider': 'sqlite',
-    'filename': ':memory:'
-}
-index_rescan_interval = 7200
-index_wait_time = 1
-
-# Site content locations
-content_folder = 'content'
-template_folder = 'templates'
-static_folder = 'static'
-static_url_path = '/static'
-
-# Image rendition cache
-image_output_subdir = '_img'
-image_cache_interval = 3600
-image_cache_age = 86400 * 30  # one month
-image_render_threads = os.cpu_count()
-
-timezone = tz.tzlocal()
-
-# Page rendering
-cache: typing.Dict[str, str] = {}
-markdown_extensions = (
-    'tables',
-    'fenced-code',
-    'footnotes',
-    'strikethrough',
-    'highlight',
-    'superscript',
-    'math',
-)
-
-# Authentication
-auth: typing.Dict[str, str] = {}
-user_list = 'users.cfg'
-admin_group = 'admin'
-auth_log_prune_interval = 3600
-auth_log_prune_age = 86400 * 30  # one month
-max_token_age = 3600
+LOGGER = logging.getLogger(__name__)
 
 
-def setup(cfg):
-    """ set up the global configuration from an object """
+class _Defaults:
+    # pylint:disable=too-few-public-methods
+    database_config = {
+        'provider': 'sqlite',
+        'filename': ':memory:'
+    }
+    index_rescan_interval = 7200
+    index_wait_time = 1
 
-    # copy the necessary configuration values over
-    this_module = sys.modules[__name__]
-    for name, value in cfg.items():
-        if hasattr(this_module, name):
-            setattr(this_module, name, value)
+    # Site content locations
+    content_folder = 'content'
+    template_folder = 'templates'
+    static_folder = 'static'
+    static_url_path = '/static'
+
+    # Image rendition cache
+    image_output_subdir = '_img'
+    image_cache_interval = 3600
+    image_cache_age = 86400 * 30  # one month
+    image_render_threads = os.cpu_count()
+
+    timezone = tz.tzlocal()
+
+    # Page rendering
+    cache: typing.Dict[str, str] = {}
+    markdown_extensions = (
+        'tables',
+        'fenced-code',
+        'footnotes',
+        'strikethrough',
+        'highlight',
+        'superscript',
+        'math',
+    )
+
+    # Authentication
+    auth: typing.Dict[str, str] = {}
+    user_list = 'users.cfg'
+    admin_group = 'admin'
+    auth_log_prune_interval = 3600
+    auth_log_prune_age = 86400 * 30  # one month
+    max_token_age = 3600
+
+
+class Config(_Defaults):
+    """ Stores configuration for a Publ app """
+    # pylint:disable=too-few-public-methods
+
+    def __init__(self, from_dict):
+        # Copy over the defaults
+        for key, val in _Defaults.__dict__.items():
+            if key[0] != '_':
+                setattr(self, key, val)
+
+        # Copy over the new configuration
+        for key, val in from_dict.items():
+            if hasattr(self, key):
+                setattr(self, key, val)
+            else:
+                LOGGER.warning("Unknown configuration key %s", key)
+
+
+config = werkzeug.local.LocalProxy(lambda: current_app.publ_config)  # pylint:disable=invalid-name

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -15,8 +15,9 @@ import slugify
 from pony import orm
 from werkzeug.utils import cached_property
 
-from . import (caching, cards, config, html_entry, links, markdown, model,
-               path_alias, queries, tokens, user, utils)
+from . import (caching, cards, html_entry, links, markdown, model, path_alias,
+               queries, tokens, user, utils)
+from .config import config
 from .utils import CallableProxy, CallableValue, TrueCallableProxy
 
 LOGGER = logging.getLogger(__name__)

--- a/publ/image/__init__.py
+++ b/publ/image/__init__.py
@@ -17,7 +17,8 @@ import flask
 import PIL.Image
 from pony import orm
 
-from .. import config, model, utils
+from .. import model, utils
+from ..config import config
 from .external import ExternalImage
 from .image import Image, ImgSpec
 from .local import LocalImage, fix_orientation

--- a/publ/image/local.py
+++ b/publ/image/local.py
@@ -14,7 +14,8 @@ import slugify
 from atomicwrites import atomic_write
 from werkzeug.utils import cached_property
 
-from .. import config, utils
+from .. import utils
+from ..config import config
 from .image import Image
 
 LOGGER = logging.getLogger(__name__)

--- a/publ/index.py
+++ b/publ/index.py
@@ -26,7 +26,8 @@ class Indexer:
     # pylint:disable=too-many-instance-attributes
     QUEUE_ITEM = typing.Tuple[str, typing.Optional[str], int]
 
-    def __init__(self, wait_time: float):
+    def __init__(self, app, wait_time: float):
+        self._app = app
         self._thread_pool = concurrent.futures.ThreadPoolExecutor(
             max_workers=1,
             thread_name_prefix="Indexer")
@@ -83,7 +84,8 @@ class Indexer:
 
         def do_task():
             try:
-                func(*args, **kwargs)
+                with self._app.app_context():
+                    func(*args, **kwargs)
             except Exception:  # pylint:disable=broad-except
                 LOGGER.exception("Task failed")
             with self._count_lock:

--- a/publ/links.py
+++ b/publ/links.py
@@ -9,7 +9,8 @@ from urllib.parse import urljoin
 from flask import request
 
 from . import entry  # pylint:disable=cyclic-import
-from . import config, image, model, utils
+from . import image, model, utils
+from .config import config
 
 
 def resolve(path: str, search_path: typing.Tuple[str, ...], absolute: bool = False) -> str:

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -13,7 +13,8 @@ import pygments.formatters
 import pygments.lexers
 import slugify
 
-from . import config, html_entry, image, links, utils
+from . import html_entry, image, links, utils
+from .config import config
 
 LOGGER = logging.getLogger(__name__)
 

--- a/publ/model.py
+++ b/publ/model.py
@@ -9,8 +9,6 @@ from enum import Enum
 
 from pony import orm
 
-from . import config
-
 db = orm.Database()  # pylint: disable=invalid-name
 
 DbEntity: orm.core.Entity = db.Entity
@@ -213,16 +211,16 @@ def reset():
                            "delete the existing database and try again.")
 
 
-def setup():
+def setup(config):
     """ Set up the database """
     rebuild = False
 
     try:
-        db.bind(**config.database_config)
+        db.bind(**config)
     except OSError:
         # Attempted to connect to a file-based database where the file didn't
         # exist
-        db.bind(**config.database_config, create_db=True)
+        db.bind(**config, create_db=True)
 
     try:
         db.generate_mapping(create_tables=True)

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -11,10 +11,11 @@ import werkzeug.exceptions as http_error
 from flask import redirect, request, send_file, url_for
 from pony import orm
 
-from . import (__version__, caching, config, image, index, model, path_alias,
-               queries, user, utils, view)
+from . import (__version__, caching, image, index, model, path_alias, queries,
+               user, utils, view)
 from .caching import cache
 from .category import Category
+from .config import config
 from .entry import Entry
 from .entry import expire_record as entry_expire_record
 from .template import Template, map_template

--- a/publ/template.py
+++ b/publ/template.py
@@ -8,7 +8,8 @@ import typing
 import arrow
 import flask
 
-from . import config, utils
+from . import utils
+from .config import config
 
 EXT_PRIORITY = ['', '.html', '.htm', '.xml', '.json', '.txt']
 

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -9,8 +9,9 @@ import requests
 import werkzeug.exceptions as http_error
 from authl.handlers import indieauth
 
-from . import config, utils
+from . import utils
 from .caching import cache
+from .config import config
 
 LOGGER = logging.getLogger(__name__)
 

--- a/publ/user.py
+++ b/publ/user.py
@@ -12,7 +12,8 @@ import flask
 from pony import orm
 from werkzeug.utils import cached_property
 
-from . import caching, config, model, tokens, utils
+from . import caching, model, tokens, utils
+from .config import config
 
 LOGGER = logging.getLogger(__name__)
 

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -14,7 +14,7 @@ import arrow
 import flask
 import werkzeug.routing
 
-from . import config
+from .config import config
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,13 @@
+""" test framework stuff """
+
+import flask
+
+from publ import config
+
+
+class PublMock(flask.Flask):
+    """ A mock class for a Publ app """
+
+    def __init__(self, cfg: dict = None):
+        super().__init__(__name__)
+        self.publ_config = config.Config(cfg or {})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+""" tests of the config manager """
+# pylint:disable=missing-docstring
+
+from publ import config
+
+from . import PublMock
+
+
+def test_config_defaults():
+    cfg = config.Config({})
+    dfl = config._Defaults  # pylint:disable=protected-access
+    for key, val in cfg.__dict__.items():
+        if key[0] != '_':
+            assert val == getattr(dfl, key)
+
+
+def test_config_overrides():
+    cfg = config.Config({'static_folder': 'kwyjibo', '_not_an_option': 'foo'})
+    assert cfg.static_folder == 'kwyjibo'
+    assert not hasattr(cfg, '_not_an_option')
+
+
+def test_config_singleton():
+    app = PublMock({'static_folder': 'berry'})
+    assert app.publ_config.static_folder == 'berry'
+    with app.app_context():
+        # pylint:disable=protected-access
+        assert config.config._get_current_object() is app.publ_config

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -3,22 +3,28 @@
 
 from publ import markdown
 
+from . import PublMock
+
 
 def test_render_title():
-    assert markdown.render_title("This *is* a test") == "This <em>is</em> a test"
-    assert markdown.render_title("This *is* a test", markup=False) == "This is a test"
-    assert markdown.render_title("This is ~~not~~ a test", markup=False) == "This is a test"
-    assert markdown.render_title("This is <s>not</s> a test", markup=False) == "This is a test"
-    assert markdown.render_title("This & That", markup=False) == "This & That"
-    assert markdown.render_title("This & That", markup=True) == "This &amp; That"
+    app = PublMock()
+    with app.app_context():
+        assert markdown.render_title("This *is* a test") == "This <em>is</em> a test"
+        assert markdown.render_title("This *is* a test", markup=False) == "This is a test"
+        assert markdown.render_title("This is ~~not~~ a test", markup=False) == "This is a test"
+        assert markdown.render_title("This is <s>not</s> a test", markup=False) == "This is a test"
+        assert markdown.render_title("This & That", markup=False) == "This & That"
+        assert markdown.render_title("This & That", markup=True) == "This &amp; That"
 
-    assert markdown.render_title('The "sun" is a liberal myth',
-                                 markup=False, smartquotes=False) == 'The "sun" is a liberal myth'
-    assert markdown.render_title('The "sun" is a liberal myth',
-                                 markup=False, smartquotes=True) == 'The “sun” is a liberal myth'
-    assert markdown.render_title('The "sun" is a liberal myth',
-                                 markup=True, smartquotes=False) == \
-        'The &quot;sun&quot; is a liberal myth'
-    assert markdown.render_title('The "sun" is a liberal myth',
-                                 markup=True, smartquotes=True) == \
-        'The &ldquo;sun&rdquo; is a liberal myth'
+        assert markdown.render_title('The "sun" is a liberal myth',
+                                     markup=False,
+                                     smartquotes=False) == 'The "sun" is a liberal myth'
+        assert markdown.render_title('The "sun" is a liberal myth',
+                                     markup=False,
+                                     smartquotes=True) == 'The “sun” is a liberal myth'
+        assert markdown.render_title('The "sun" is a liberal myth',
+                                     markup=True, smartquotes=False) == \
+            'The &quot;sun&quot; is a liberal myth'
+        assert markdown.render_title('The "sun" is a liberal myth',
+                                     markup=True, smartquotes=True) == \
+            'The &ldquo;sun&rdquo; is a liberal myth'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -226,30 +226,33 @@ def test_listlike():
 def test_parse_date():
     """ tests for the date parser """
     import arrow
-    from publ import config
+    from . import PublMock
 
-    def make_date(year=None, month=None, day=None):
-        return arrow.Arrow(year=year or 1,
-                           month=month or 1,
-                           day=day or 1,
-                           tzinfo=config.timezone)
+    app = PublMock()
 
-    with pytest.raises(ValueError):
-        utils.parse_date("not a date")
-    with pytest.raises(ValueError):
-        utils.parse_date("12345678")
-    with pytest.raises(ValueError):
-        utils.parse_date("")
+    with app.app_context():
+        def make_date(year=None, month=None, day=None):
+            return arrow.Arrow(year=year or 1,
+                               month=month or 1,
+                               day=day or 1,
+                               tzinfo=app.publ_config.timezone)
 
-    assert utils.parse_date('1978-06-14') == (make_date(1978, 6, 14), 'day', utils.DAY_FORMAT)
-    assert utils.parse_date('19780614') == (make_date(1978, 6, 14), 'day', utils.DAY_FORMAT)
+        with pytest.raises(ValueError):
+            utils.parse_date("not a date")
+        with pytest.raises(ValueError):
+            utils.parse_date("12345678")
+        with pytest.raises(ValueError):
+            utils.parse_date("")
 
-    assert utils.parse_date('1983-07') == (make_date(1983, 7), 'month', utils.MONTH_FORMAT)
-    assert utils.parse_date('198307') == (make_date(1983, 7), 'month', utils.MONTH_FORMAT)
+        assert utils.parse_date('1978-06-14') == (make_date(1978, 6, 14), 'day', utils.DAY_FORMAT)
+        assert utils.parse_date('19780614') == (make_date(1978, 6, 14), 'day', utils.DAY_FORMAT)
 
-    assert utils.parse_date("1979") == (make_date(1979), 'year', utils.YEAR_FORMAT)
+        assert utils.parse_date('1983-07') == (make_date(1983, 7), 'month', utils.MONTH_FORMAT)
+        assert utils.parse_date('198307') == (make_date(1983, 7), 'month', utils.MONTH_FORMAT)
 
-    assert utils.parse_date('19810505_w') == (make_date(1981, 5, 4), 'week', utils.WEEK_FORMAT)
+        assert utils.parse_date("1979") == (make_date(1979), 'year', utils.YEAR_FORMAT)
+
+        assert utils.parse_date('19810505_w') == (make_date(1981, 5, 4), 'week', utils.WEEK_FORMAT)
 
 
 def test_find_file():


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Removes the module global config; fixes #113 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Now the configuration is stored on an object that's owned by the Publ app, instead of being stashed in hinky, fragile module globals.

Also this finally starts to build a `PublMock` class for doing further unit test cases.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
Instead of doing `from . import config` you do `from .config import config`.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
test coverage 100%, manual smoke tests continue to work

## Got a site to show off?

<!-- If so, link to it here! -->
