### PR TITLE
Add enumerable code blocks and refactor the way counters work

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -200,7 +200,8 @@ class Category(caching.Memoizable):
             if self._meta:
                 return flask.Markup(markdown.to_html(self._meta.get_payload(),
                                                      args=kwargs,
-                                                     search_path=self.search_path))
+                                                     search_path=self.search_path,
+                                                     counter=markdown.ItemCounter()))
             return ''
 
         if self._meta and self._meta.get_payload():

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -23,7 +23,8 @@ ArgDict = typing.Dict[str, typing.Any]
 ListLike = typing.Union[typing.List[T],
                         typing.Tuple[T, ...],
                         typing.Set[T]]
-TagAttrs = typing.Dict[str, typing.Union[str, bool, None]]
+TagAttr = typing.Union[str, bool, None]
+TagAttrs = typing.Dict[str, TagAttr]
 
 
 class CallableProxy:
@@ -215,7 +216,7 @@ def make_tag(name: str,
     if start_end:
         text += ' /' if attrs else '/'
     text += '>'
-    return flask.Markup(text)
+    return text
 
 
 def file_fingerprint(fullpath: str) -> str:

--- a/tests/content/fenced code.md
+++ b/tests/content/fenced code.md
@@ -1,0 +1,51 @@
+Title: Fenced code blocks
+Date: 2020-06-18 15:42:24-07:00
+Entry-ID: 2645
+UUID: 76ddc3e6-41e0-5bb2-b635-bd3e1cb737a7
+
+Code block in the intro:
+
+```text
+This is a text file.
+
+It contains a lot of text.
+```
+
+Second code block in the intro:
+
+```cpp
+#include <cstdlib>
+
+int main() {
+    std::cout << "Hello world" << std::endl;
+    return 0
+}
+```
+
+```
+This is text with no declared language.
+```
+
+.....
+
+
+```
+! a caption
+This code block has no declared language.
+
+Oh well!
+```
+
+```skdjflsjflsl
+This code block declares an unknown language.
+```
+
+foo
+
+```python
+! invalid.py
+def foo():
+    return None + "bar"
+```
+
+bar

--- a/tests/templates/style.css
+++ b/tests/templates/style.css
@@ -33,16 +33,81 @@ h4 a {
     text-decoration: none;
 }
 
-code,
-.highlight pre {
+.blockcode {
     background: #eee;
+    border: solid #777 1px;
+    border-radius: 1ex;
+    margin-bottom: 1em;
+    overflow: hidden;
+}
+
+.blockcode .caption {
+    font-size: small;
+    color: #77f;
+    font-style: italic;
+    border-bottom: solid #777 1px;
+    padding: 0 1ex;
+    background: #fff7f7;
+}
+
+code,
+pre {
     font-family: 'Andale Mono', 'Liberation Mono', 'Monaco', 'Lucida Console', monospace;
+    margin: 0;
+    padding: 0;
+    line-height: 1em;
 }
 
 pre {
-    background: #eee;
-    border: dotted black 1px;
-    padding: 1ex;
+    overflow-x: auto;
+}
+
+.line-content {
+    width: 100%;
+    padding: 0 1ex;
+}
+
+.highlight {
+    display: table;
+    counter-reset: codeline;
+    border-collapse: collapse;
+}
+
+.highlight .line {
+    display: table-row;
+    counter-increment: codeline;
+}
+
+pre .line {
+    width: 100%;
+}
+
+pre .line:first-child .line-content {
+    padding-top: 0.5em;
+}
+
+pre .line:last-child .line-content {
+    padding-bottom: 0.5em;
+}
+
+.highlight .line-number:hover {
+    background: rgba(255,255,0,0.5);
+}
+.highlight .line-number::before {
+    display: table-cell;
+    content: counter(codeline);
+    font-size: small;
+    font-family: 'Trebuchet MS', 'Verdana', 'Liberation Sans', 'Helvetica', 'Arial', sans-serif;
+    min-width: 2em;
+    text-align: right;
+    padding: 0 0.5ex;
+    color: #555;
+    vertical-align: baseline;
+}
+
+.highlight .line-content {
+    display: table-cell;
+    border-left: solid #999 1px;
 }
 
 .images {


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Makes it possible to number lines in code blocks via CSS, and also provide permalinks to each line.

## Detailed description

Code blocks are now line-enumerable, and provide per-line permalinks. These are all to be enabled via CSS. Code blocks that do not declare a language do not get the enumeration; to enumerate a text block, declare a language of `text`.

There is also additional Markdown extension; if the first line of a code block starts with `!`, that line will be used as a title caption for the code block.

This required refactoring item counters, which now count independently of any underlying buffers, which makes
it easier to reconcile IDs between each other. This helps to simplify the way we track items such as TOC headings, footnotes, and code blocks.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
This changes the structure of fenced code blocks' HTML, which might have an impact on existing stylesheets. All efforts were taken to make this impact as minimal as possible.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added code block tests, and thoroughly manually-tested code blocks, TOCs, and footnotes to ensure they still enumerate and permalink correctly.

## Got a site to show off?

<!-- If so, link to it here! -->
