### PR TITLE
Improve block code and image set semantics

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -507,11 +507,13 @@ class Entry(caching.Memoizable):
         """
         # pylint:disable=too-many-arguments
         if is_markdown:
-            if 'footnotes_link' not in args:
-                args['footnotes_link'] = self.link(absolute=args.get('absolute'))
-
-            if 'toc_link' not in args:
-                args['toc_link'] = self.link(absolute=args.get('absolute'))
+            # Set defaults for the ID link generators, so permalinks from category
+            # pages work correctly
+            for link_flag in ('footnotes_link', 'toc_link'):
+                if link_flag not in args:
+                    args[link_flag] = self.link(absolute=args.get('absolute'))
+            if not isinstance(args.get('code_number_links'), str):
+                args['code_number_links'] = self.link(absolute=args.get('absolute'))
 
             return markdown.to_html(
                 text,

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -509,11 +509,10 @@ class Entry(caching.Memoizable):
         if is_markdown:
             # Set defaults for the ID link generators, so permalinks from category
             # pages work correctly
-            for link_flag in ('footnotes_link', 'toc_link'):
-                if link_flag not in args:
-                    args[link_flag] = self.link(absolute=args.get('absolute'))
-            if not isinstance(args.get('code_number_links'), str):
-                args['code_number_links'] = self.link(absolute=args.get('absolute'))
+            default_link = self.link(absolute=args.get('absolute'))
+            for link_flag in ('footnotes_link', 'toc_link', 'code_number_links'):
+                if link_flag not in args or args[link_flag] is True:
+                    args[link_flag] = default_link
 
             return markdown.to_html(
                 text,

--- a/publ/image/__init__.py
+++ b/publ/image/__init__.py
@@ -183,7 +183,6 @@ def _get_image(path: str, search_path: typing.Tuple[str, ...]) -> Image:
 
 def parse_img_config(text: str) -> typing.Tuple[str, utils.ArgDict]:
     """ Parses an arglist into arguments for Image, as a kwargs dict """
-    # per https://stackoverflow.com/a/49723227/318857
 
     text, pos_args, kwargs = utils.parse_spec(text, 2)
 
@@ -199,21 +198,19 @@ def parse_img_config(text: str) -> typing.Tuple[str, utils.ArgDict]:
     return text, kwargs
 
 
-def parse_image_spec(spec: str) -> typing.Tuple[str, utils.ArgDict, typing.Optional[str]]:
+def parse_image_spec(path: str) -> typing.Tuple[str, utils.ArgDict, typing.Optional[str]]:
     """ Parses out a Publ-Markdown image spec into a tuple of path, args, title """
 
     title: typing.Optional[str] = None
 
-    # I was having trouble coming up with a single RE that did it right,
-    # so let's just break it down into sub-problems. First, parse out the
-    # alt text...
-    match = re.match(r'(.+)\s+\"(.*)\"\s*$', spec)
+    # Parse out the title..
+    match = re.match(r'(.+)\s+\"(.*)\"\s*$', path)
     if match:
-        spec, title = match.group(1, 2)
+        path, title = match.group(1, 2)
 
-    spec, args = parse_img_config(spec)
+    path, args = parse_img_config(path)
 
-    return spec, args, (title and html.unescape(title))
+    return path, args, (title and html.unescape(title))
 
 
 def get_spec_list(image_specs: str, container_args: utils.ArgDict):

--- a/publ/image/image.py
+++ b/publ/image/image.py
@@ -8,7 +8,6 @@ import flask
 
 from .. import utils
 
-ImgSpec = typing.Dict[str, typing.Any]
 ImgSize = typing.Tuple[int, int]
 RenditionAttrs = typing.Dict[str, typing.Any]
 
@@ -37,7 +36,7 @@ class Image(ABC):
 
     @abstractmethod
     def _get_img_attrs(self,
-                       spec: ImgSpec,
+                       spec: utils.ArgDict,
                        style_parts: typing.List[str]) -> utils.TagAttrs:
         """ Get the img attributes for the given rendition arguments. Style parts
         should be appended to the style_parts instead.

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -524,7 +524,8 @@ class TagSet(typing.Set[str]):
 
 def strip_single_paragraph(text: str):
     """ If the provided HTML text has only a single paragraph, strip it off. """
-    stripped = re.sub(r'<p>(.*)</p>', r'\1', text.strip())
+
+    stripped = re.sub(r'^<p>(.*)</p>$', r'\1', text.strip())
     if '<p>' in stripped:
         return text
     return stripped

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -1,6 +1,7 @@
 # utils.py
 """ Some useful utilities that don't belong anywhere else """
 
+import ast
 import functools
 import html
 import html.parser
@@ -520,9 +521,43 @@ class TagSet(typing.Set[str]):
     def __lt__(self, other):
         return self._fold(self) < self._fold(other)
 
-def strip_single_paragraph(text:str):
+
+def strip_single_paragraph(text: str):
     """ If the provided HTML text has only a single paragraph, strip it off. """
-    stripped = re.sub(r'<p>(.*)</p>', r'\1', text)
+    stripped = re.sub(r'<p>(.*)</p>', r'\1', text.strip())
     if '<p>' in stripped:
         return text
     return stripped
+
+
+def parse_spec(text: str, pos_limit: int = None) -> typing.Tuple[str, list, ArgDict]:
+    """ Given a string like ``foo{10,bar=baz}``, parse out the argument lists.
+
+    :param str text: The text to parse
+    :param int pos_limit: The maximum number of positional args to allow
+    :returns: Tuple of text, pos_args, kw_args
+    """
+    match = re.match(r'([^\{]*)(\{(.*)\})$', text)
+    if match:
+        pos_args, kw_args = parse_arglist(match.group(3), pos_limit)
+        return match.group(1), pos_args, kw_args
+
+    return text, [], {}
+
+
+def parse_arglist(args: str, pos_limit: int = None) -> typing.Tuple[list, ArgDict]:
+    """ Parse an argument list into pos_args, kw_args"""
+    tree = ast.parse(f'f({args})')
+    expr = typing.cast(ast.Expr, tree.body[0])
+    funccall = typing.cast(ast.Call, expr.value)
+
+    pos_args = [ast.literal_eval(arg) for arg in funccall.args]
+    if pos_limit is not None and len(pos_args) > pos_limit:
+        raise TypeError(
+            f"Expected at most {pos_limit} positional args but {len(pos_args)} were given")
+
+    kwargs = {arg.arg: ast.literal_eval(arg.value)
+              for arg in funccall.keywords if arg.arg}
+
+    LOGGER.debug("pos_args=%s kw_args=%s", pos_args, kwargs)
+    return pos_args, kwargs

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -519,3 +519,10 @@ class TagSet(typing.Set[str]):
 
     def __lt__(self, other):
         return self._fold(self) < self._fold(other)
+
+def strip_single_paragraph(text:str):
+    """ If the provided HTML text has only a single paragraph, strip it off. """
+    stripped = re.sub(r'<p>(.*)</p>', r'\1', text)
+    if '<p>' in stripped:
+        return text
+    return stripped

--- a/tests/content/fenced code.md
+++ b/tests/content/fenced code.md
@@ -36,8 +36,11 @@ This code block has no declared language.
 Oh well!
 ```
 
+
 ```skdjflsjflsl
 This code block declares an unknown language.
+
+As a result, we treat it as plain text.
 ```
 
 foo
@@ -49,3 +52,17 @@ def foo():
 ```
 
 bar
+
+```markdown
+\![literal escape on the first exclamation mark](foo)
+```
+
+```markdown
+
+![a blank line works too]()
+```
+
+```markdown
+! A caption line
+![An image line]()
+```

--- a/tests/content/fenced code.md
+++ b/tests/content/fenced code.md
@@ -66,3 +66,28 @@ bar
 ! A caption line
 ![An image line]()
 ```
+
+Arguments:
+
+```bash{code_highlight=False}
+cat << EOF
+This code has had highlighting disabled.
+
+Test 1
+Test 2
+EOF
+```
+
+
+
+```html{code_number_links=False}
+<span>This code has had number links disabled</span>
+```
+
+```{code_number_links=False}
+No declared language, and disabled number links
+```
+
+```{code_number_links=True}
+number links explicitly set True
+```

--- a/tests/content/fenced code.md
+++ b/tests/content/fenced code.md
@@ -49,6 +49,9 @@ foo
 ! invalid.py
 def foo():
     return None + "bar"
+
+def bar():
+    return "bar" + foo()
 ```
 
 bar
@@ -90,4 +93,20 @@ No declared language, and disabled number links
 
 ```{code_number_links=True}
 number links explicitly set True
+but there is no declared language
+```
+
+```
+\! first line has !
+second line does not
+```
+
+```
+
+! first line is blank
+```
+
+```
+!
+! empty caption
 ```

--- a/tests/content/images/figure.md
+++ b/tests/content/images/figure.md
@@ -1,0 +1,28 @@
+Title: Figures
+Date: 2020-07-27 12:52:06-07:00
+Entry-ID: 1028
+UUID: 936c16b2-e4e0-56bf-923a-6dd8c6dde945
+
+Test of `<figure>` image sets
+
+.....
+
+Figure=`True`:
+
+![{figure=True}](rawr.jpg)
+
+Caption, no explicit figure class:
+
+![{caption='A rawr'}](rawr.jpg)
+
+Figure class, no caption:
+
+![{figure='rawr'}](rawr.jpg)
+
+Caption contains markdown:
+
+![{caption='a *rawr*[^fn]\n\n[^fn]: rawr'}](rawr.jpg)
+
+Multiple paragraphs in caption:
+
+![{caption='a rawr\n\nit says rawr'}](rawr.jpg)

--- a/tests/content/images/image renditions.md
+++ b/tests/content/images/image renditions.md
@@ -12,28 +12,29 @@ Image rendition tests
 
 External image with width set
 
-![](//publ.plaidweb.site/static/images/IMG_0377.jpg{250} "so smol")
+![](//placekitten.com/800/600{250} "so smol")
 
-`![](//publ.plaidweb.site/static/images/IMG_0377.jpg{250} "so smol")`
+`![](//placekitten.com/800/600{250} "so smol")`
 
 External image with height set
 
-![](//publ.plaidweb.site/static/images/IMG_0377.jpg{height=250} "less smol")
+![](//placekitten.com/800/600{height=250} "less smol")
 
-`![](//publ.plaidweb.site/static/images/IMG_0377.jpg{height=250} "less smol")`
+`![](//placekitten.com/800/600{height=250} "less smol")`
 
 External image with width and height set, with different scaling modes:
 
 ![{320,320,div_class="gallery",gallery_id="sizing"}](
-//publ.plaidweb.site/static/images/IMG_0377.jpg "fit"
-| //publ.plaidweb.site/static/images/IMG_0377.jpg{resize="fill"} "fill"
-| //publ.plaidweb.site/static/images/IMG_0377.jpg{resize="stretch"} "stretch")
+//placekitten.com/960/480 "fit"
+| //placekitten.com/960/480{resize="fill"} "fill"
+| //placekitten.com/960/480{resize="stretch"} "stretch")
 
 ```markdown
+
 ![{320,320,div_class="gallery",gallery_id="sizing"}](
-//publ.plaidweb.site/static/images/IMG_0377.jpg "fit"
-| //publ.plaidweb.site/static/images/IMG_0377.jpg{resize="fill"} "fill"
-| //publ.plaidweb.site/static/images/IMG_0377.jpg{resize="stretch"} "stretch")
+//placekitten.com/960/480 "fit"
+| //placekitten.com/960/480{resize="fill"} "fill"
+| //placekitten.com/960/480{resize="stretch"} "stretch")
 ```
 
 Image using static path
@@ -45,9 +46,9 @@ Image using static path
 
 Force absolute URLs
 
-![{640,320,absolute=True}](//publ.plaidweb.site/static/images/IMG_0377.jpg | @images/IMG_0377.jpg)
+![{640,320,absolute=True}](//placekitten.com/800/600 | @images/IMG_0377.jpg)
 
-`![{640,320,absolute=True}](//publ.plaidweb.site/static/images/IMG_0377.jpg | @images/IMG_0377.jpg)`
+`![{640,320,absolute=True}](//placekitten.com/800/600 | @images/IMG_0377.jpg)`
 
 
 ## Local images
@@ -63,6 +64,7 @@ rawr.jpg "image 3"
 )
 
 ```markdown
+
 ![alt text](
 rawr.jpg{width=240} "test lightbox" |
 rawr.jpg{width=120} |
@@ -76,20 +78,23 @@ rawr.jpg "image 3"
 
 ![alt text](rawr.jpg{120,crop=(0,0,240,352)} "test crop (left half of rawr.jpg, scaled down)")
 
-```
+```markdown
+
 ![alt text](rawr.jpg{120,crop=(0,0,240,352)} "test crop (left half of rawr.jpg, scaled down)")
 ```
 
 ![](rawr.jpg{gallery_id='crops',crop=(107,72,89,82)} "just rawr's eye")
 
-```
+```markdown
+
 ![](rawr.jpg{gallery_id='crops',crop=(107,72,89,82)} "just rawr's eye")
 ```
 
 ![](croptest.png{gallery_id='crops',crop=(462,389,183,133),fullsize_crop=(119,142,343,247)}
     "different crops for thumbnail as fullsize")
 
-```
+```markdown
+
 ![](croptest.png{gallery_id='crops',crop=(462,389,183,133),fullsize_crop=(119,142,343,247)}
     "different crops for thumbnail as fullsize")
 ```
@@ -98,7 +103,8 @@ rawr.jpg "image 3"
   croptest.png{crop='119,142,343,247',resize='fit'} "fit crop"
 | croptest.png{crop='119,142,343,247',resize='fill'} "fill crop")
 
-```
+```markdown
+
 ![{100,100}](
   croptest.png{crop='119,142,343,247',resize='fit'} "fit crop"
 | croptest.png{crop='119,142,343,247',resize='fill'} "fill crop")
@@ -123,11 +129,12 @@ should still be in a paragraph
 ![such gallery{255,gallery_id="rawry"}](rawr.jpg
 | rawr.jpg{fullscreen_width=50} "Rawr!"
 | rawr.jpg{100}
-| //publ.plaidweb.site/static/images/IMG_0377.jpg)
+| //placekitten.com/1280/720)
 
 ```markdown
+
 ![such gallery{255,gallery_id="rawry"}](rawr.jpg | rawr.jpg{fullscreen_width=50} "Rawr!" | rawr.jpg{100}
-| //publ.plaidweb.site/static/images/IMG_0377.jpg)
+| //placekitten.com/800/600)
 ```
 
 ## PNG transparency
@@ -164,6 +171,7 @@ notsmiley.png{quality=1} "quality 1"
 )
 
 ```markdown
+
 ![{256,background='cyan',format='jpg'}](
 notsmiley.png{quality=1} "quality 1"
 | notsmiley.png{quality=50} "quality 50"
@@ -186,6 +194,7 @@ notsmiley.png{quality=1} "quality 1"
 )
 
 ```markdown
+
 ![{256,256}](Landscape_4.jpg{format='png'} "png24"
 | Landscape_4.jpg{format='png',quantize=0} "png8 0"
 | Landscape_4.jpg{format='png',quantize=128} "png8 128"
@@ -208,7 +217,8 @@ notsmiley.png{quality=1} "quality 1"
 | Landscape_1.jpg{scale_filter='xyzzy'} "xyzzy"
 )
 
-```
+```markdown
+
 ![{512,512,format='png'}](Landscape_1.jpg "default"
 | Landscape_1.jpg{scale_filter='nearest'} "nearest"
 | Landscape_1.jpg{scale_filter='box'} "box"

--- a/tests/content/images/image renditions.md
+++ b/tests/content/images/image renditions.md
@@ -12,28 +12,28 @@ Image rendition tests
 
 External image with width set
 
-![](//publ.beesbuzz.biz/static/images/IMG_0377.jpg{250} "so smol")
+![](//publ.plaidweb.site/static/images/IMG_0377.jpg{250} "so smol")
 
-`![](//publ.beesbuzz.biz/static/images/IMG_0377.jpg{250} "so smol")`
+`![](//publ.plaidweb.site/static/images/IMG_0377.jpg{250} "so smol")`
 
 External image with height set
 
-![](//publ.beesbuzz.biz/static/images/IMG_0377.jpg{height=250} "less smol")
+![](//publ.plaidweb.site/static/images/IMG_0377.jpg{height=250} "less smol")
 
-`![](//publ.beesbuzz.biz/static/images/IMG_0377.jpg{height=250} "less smol")`
+`![](//publ.plaidweb.site/static/images/IMG_0377.jpg{height=250} "less smol")`
 
 External image with width and height set, with different scaling modes:
 
 ![{320,320,div_class="gallery",gallery_id="sizing"}](
-//publ.beesbuzz.biz/static/images/IMG_0377.jpg "fit"
-| //publ.beesbuzz.biz/static/images/IMG_0377.jpg{resize="fill"} "fill"
-| //publ.beesbuzz.biz/static/images/IMG_0377.jpg{resize="stretch"} "stretch")
+//publ.plaidweb.site/static/images/IMG_0377.jpg "fit"
+| //publ.plaidweb.site/static/images/IMG_0377.jpg{resize="fill"} "fill"
+| //publ.plaidweb.site/static/images/IMG_0377.jpg{resize="stretch"} "stretch")
 
 ```markdown
 ![{320,320,div_class="gallery",gallery_id="sizing"}](
-//publ.beesbuzz.biz/static/images/IMG_0377.jpg "fit"
-| //publ.beesbuzz.biz/static/images/IMG_0377.jpg{resize="fill"} "fill"
-| //publ.beesbuzz.biz/static/images/IMG_0377.jpg{resize="stretch"} "stretch")
+//publ.plaidweb.site/static/images/IMG_0377.jpg "fit"
+| //publ.plaidweb.site/static/images/IMG_0377.jpg{resize="fill"} "fill"
+| //publ.plaidweb.site/static/images/IMG_0377.jpg{resize="stretch"} "stretch")
 ```
 
 Image using static path
@@ -45,9 +45,9 @@ Image using static path
 
 Force absolute URLs
 
-![{640,320,absolute=True}](//publ.beesbuzz.biz/static/images/IMG_0377.jpg | @images/IMG_0377.jpg)
+![{640,320,absolute=True}](//publ.plaidweb.site/static/images/IMG_0377.jpg | @images/IMG_0377.jpg)
 
-`![{640,320,absolute=True}](//publ.beesbuzz.biz/static/images/IMG_0377.jpg | @images/IMG_0377.jpg)`
+`![{640,320,absolute=True}](//publ.plaidweb.site/static/images/IMG_0377.jpg | @images/IMG_0377.jpg)`
 
 
 ## Local images
@@ -123,11 +123,11 @@ should still be in a paragraph
 ![such gallery{255,gallery_id="rawry"}](rawr.jpg
 | rawr.jpg{fullscreen_width=50} "Rawr!"
 | rawr.jpg{100}
-| //publ.beesbuzz.biz/static/images/IMG_0377.jpg)
+| //publ.plaidweb.site/static/images/IMG_0377.jpg)
 
 ```markdown
 ![such gallery{255,gallery_id="rawry"}](rawr.jpg | rawr.jpg{fullscreen_width=50} "Rawr!" | rawr.jpg{100}
-| //publ.beesbuzz.biz/static/images/IMG_0377.jpg)
+| //publ.plaidweb.site/static/images/IMG_0377.jpg)
 ```
 
 ## PNG transparency

--- a/tests/static/fancy-code.css
+++ b/tests/static/fancy-code.css
@@ -1,0 +1,85 @@
+/** Separated CSS for the fancy code blocks on this site.
+
+This reformats fenced-code blocks into tables with CSS-generated line numbers on each line.
+
+*/
+
+.blockcode {
+    border: solid #ccc 1px;
+    border-radius: 1ex;
+    margin-bottom: 1em;
+    overflow: hidden;
+}
+
+.blockcode figcaption {
+    font-size: small;
+    color: #77f;
+    font-style: italic;
+    border-bottom: solid #777 1px;
+    padding: 0 1ex;
+    background: #fff7f7;
+}
+
+/* Set the code font */
+code,
+pre {
+    font-family: 'Andale Mono', 'Liberation Mono', 'Monaco', 'Lucida Console', monospace;
+    background: #eee;
+}
+
+/* Set up <pre> blocks to work as a table with a row per line, and put the lines in cells */
+.blockcode pre {
+    overflow-x: auto;
+    display: table;
+    width: 100%;
+    counter-reset: codeline;
+    border-collapse: collapse;
+    margin: 0;
+    padding: 0;
+}
+
+.blockcode pre .line-content {
+    padding: 0 1ex;
+    width: 100%;
+    display: table-cell;
+}
+
+.blockcode pre .line {
+    display: table-row;
+    counter-increment: codeline;
+}
+
+/* Force empty lines to have a space in them */
+.blockcode pre .line::after {
+    content: '\00a0';
+}
+
+/* Add some inner padding to the first and last lines */
+.blockcode pre .line:first-child .line-content {
+    padding-top: 0.5em;
+}
+
+.blockcode pre .line:last-child .line-content {
+    padding-bottom: 0.5em;
+}
+
+/* Configure display of the line numbers, if present */
+.blockcode pre .line-number:hover {
+    background: rgba(255,255,0,0.5);
+}
+.blockcode pre .line-number::before {
+    display: table-cell;
+    content: counter(codeline);
+    font-size: small;
+    font-family: 'Trebuchet MS', 'Verdana', 'Liberation Sans', 'Helvetica', 'Arial', sans-serif;
+    min-width: 2em;
+    text-align: right;
+    padding: 0 0.5ex;
+    color: #555;
+    vertical-align: baseline;
+}
+
+/* If there are line numbers, add a border to the left side of the content cells */
+.blockcode pre[data-line-numbers] .line-content {
+    border-left: solid #999 1px;
+}

--- a/tests/templates/style.css
+++ b/tests/templates/style.css
@@ -1,4 +1,5 @@
 @import url('{{static("pygments.default.css")}}');
+@import url('{{static("fancy-code.css")}}');
 
 html {
     padding: 0;
@@ -33,14 +34,6 @@ h4 a {
     text-decoration: none;
 }
 
-.blockcode {
-    background: #eee;
-    border: solid #777 1px;
-    border-radius: 1ex;
-    margin-bottom: 1em;
-    overflow: hidden;
-}
-
 figure {
     border: dashed black 1px;
 }
@@ -50,64 +43,6 @@ figcaption {
     color: #77f;
     font-style: italic;
     padding: 0 1ex;
-}
-
-.blockcode figcaption {
-    border-bottom: solid #777 1px;
-    background: #fff7f7;
-}
-
-code,
-pre {
-    font-family: 'Andale Mono', 'Liberation Mono', 'Monaco', 'Lucida Console', monospace;
-    margin: 0;
-    padding: 0;
-}
-
-pre {
-    overflow-x: auto;
-    display: table;
-    counter-reset: codeline;
-    border-collapse: collapse;
-}
-
-pre .line {
-    display: table-row;
-    counter-increment: codeline;
-    width: 100%;
-}
-
-pre .line-content {
-    display: table-cell;
-    width: 100%;
-    padding: 0 1ex;
-}
-
-pre .line:first-child .line-content {
-    padding-top: 0.5ex;
-}
-
-pre .line:last-child .line-content {
-    padding-bottom: 0.5ex;
-}
-
-pre .line-number:hover {
-    background: rgba(255,255,0,0.5);
-}
-pre .line-number::before {
-    display: table-cell;
-    content: counter(codeline);
-    font-size: small;
-    font-family: 'Trebuchet MS', 'Verdana', 'Liberation Sans', 'Helvetica', 'Arial', sans-serif;
-    min-width: 2em;
-    text-align: right;
-    padding: 0 0.5ex;
-    color: #555;
-    vertical-align: baseline;
-}
-
-pre .line-content {
-    border-left: solid #999 1px;
 }
 
 .images {

--- a/tests/templates/style.css
+++ b/tests/templates/style.css
@@ -41,12 +41,19 @@ h4 a {
     overflow: hidden;
 }
 
-.blockcode .caption {
+figure {
+    border: dashed black 1px;
+}
+
+figcaption {
     font-size: small;
     color: #77f;
     font-style: italic;
-    border-bottom: solid #777 1px;
     padding: 0 1ex;
+}
+
+.blockcode figcaption {
+    border-bottom: solid #777 1px;
     background: #fff7f7;
 }
 
@@ -55,45 +62,39 @@ pre {
     font-family: 'Andale Mono', 'Liberation Mono', 'Monaco', 'Lucida Console', monospace;
     margin: 0;
     padding: 0;
-    line-height: 1em;
 }
 
 pre {
     overflow-x: auto;
-}
-
-.line-content {
-    width: 100%;
-    padding: 0 1ex;
-}
-
-.highlight {
     display: table;
     counter-reset: codeline;
     border-collapse: collapse;
 }
 
-.highlight .line {
+pre .line {
     display: table-row;
     counter-increment: codeline;
-}
-
-pre .line {
     width: 100%;
 }
 
+pre .line-content {
+    display: table-cell;
+    width: 100%;
+    padding: 0 1ex;
+}
+
 pre .line:first-child .line-content {
-    padding-top: 0.5em;
+    padding-top: 0.5ex;
 }
 
 pre .line:last-child .line-content {
-    padding-bottom: 0.5em;
+    padding-bottom: 0.5ex;
 }
 
-.highlight .line-number:hover {
+pre .line-number:hover {
     background: rgba(255,255,0,0.5);
 }
-.highlight .line-number::before {
+pre .line-number::before {
     display: table-cell;
     content: counter(codeline);
     font-size: small;
@@ -105,8 +106,7 @@ pre .line:last-child .line-content {
     vertical-align: baseline;
 }
 
-.highlight .line-content {
-    display: table-cell;
+pre .line-content {
     border-left: solid #999 1px;
 }
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Puts block code inside `<figure>` and cleans up the semantic HTML; fixes #399 

Allows putting image sets inside `<figure>`; fixes #400 

Also various cleanups and refactoring around some of the code touched by these things

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

The HTML structure of the fenced code blocks was a bit half-baked and a little too ad-hoc for my tastes. Rather than using yet another pile of poorly-specified unsemantic `<div>`s it seemed better to use semantic `<figure>`/`<figcaption>` elements. Switching to that also highlighted some of the issues with how image sets are handled, and the lack of ability to actually customize code block behavior at any level, so this adds a few configuration settings for fenced code as well as the ability to specify settings at the code block level, and also refactors argument parsing to make it more readily-available to other components in the future.

Image sets can now be configured to use a `<figure>` instead of or in addition to the `<div>`, although this is opt-in (as the `<div>` settings were already driven by configuration and defaulted to disabled). There is also a new `caption` configuration value that generates a `<figcaption>` from embedded Markdown and implies `<figure>`.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

Code block stylesheets will almost certainly need to change again.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added more tests to the `fenced code.md` and verified existing tests on images.

## Got a site to show off?

<!-- If so, link to it here! -->
