### PR TITLE
Add authorization check to entry attachments

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -541,7 +541,10 @@ class Entry(caching.Memoizable):
                                          })
             if order:
                 query = query.order_by(*queries.ORDER_BY[order])
-            return [Entry.load(e) for e in query]
+            cur_user = user.get_active()
+
+            return [Entry.load(e) for e in query
+                    if e.is_authorized(cur_user) or tokens.request(cur_user)]
 
         return CallableProxy(_get_attachments)
 

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -128,4 +128,3 @@ def request(user):
     as being upgradeable. """
     if not user:
         flask.g.stash['needs_token'] = True
-    return user

--- a/tests/content/attach/auth.md
+++ b/tests/content/attach/auth.md
@@ -1,0 +1,7 @@
+Title: Attachment that requires authorization
+Auth: *
+Date: 2020-07-29 22:44:54-07:00
+Entry-ID: 2102
+UUID: 07be9de4-f16e-5865-81c3-4f4e2536eb65
+
+This attachment needs authorization.

--- a/tests/content/attach/main.md
+++ b/tests/content/attach/main.md
@@ -2,6 +2,7 @@ Title: Main entry
 Date: 2020-05-17 16:37:14-07:00
 UUID: 65e871c6-0c4f-5dca-98a0-765c329d85f9
 Attach: supplement 1.md
+Attach: auth.md
 Attach: 1349
 Entry-ID: 1208
 

--- a/tests/templates/attach/entry.html
+++ b/tests/templates/attach/entry.html
@@ -12,7 +12,7 @@
 {% block entrymore scoped %}
 {{ super() }}
 {% for attach in entry.attachments(order='title') %}
-<h3><a href="{{attach.link}}">{{attach.title}}</a></h3>
+<h3>{{attach.id}} <a href="{{attach.link}}">{{attach.title}}</a></h3>
 
 {{attach.body}}
 {{attach.more}}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
`Entry.attachments` only returns attachments that the user is authorized to see. Fixes #379 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Also changed `tokens.request()` to return `None`, since there's no reason to actually return the user that's passed in and doing this allows its use inside a list filter.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added authorization test to the `attach/` tests.

## Got a site to show off?

<!-- If so, link to it here! -->
