### PR TITLE
Allow path-alias to override exceptions

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -187,6 +187,9 @@ def render_exception(error):
     """ Catch-all renderer for the top-level exception handler """
 
     LOGGER.debug("render_exception %s %s", type(error), error)
+    result = handle_path_alias()
+    if result:
+        return result
 
     # Effectively strip off the leading '/', so map_template can decide
     # what the actual category is

--- a/tests/content/aliases/exceptions.md
+++ b/tests/content/aliases/exceptions.md
@@ -1,0 +1,13 @@
+Title: Exception case
+Path-Alias: /_error
+Path-Alias: /error
+Path-Alias: /_foo/_bar/baz
+Path-Alias: /_login
+Date: 2020-08-03 22:59:49-07:00
+Entry-ID: 1358
+UUID: 8393f616-b08f-55fa-b191-5de9d26fb1b4
+
+This entry should be reachable from [`/_error`](/_error), [`/error`](/error), and [`/_foo/_bar/baz`](/_foo/_bar/baz).
+But [`/_alternate`](/_alternate) and [`/_alternate`](/_alternate_index) should still be an error,
+and [`/_login`](/_login) should still go to the login page.
+

--- a/tests/templates/index.html
+++ b/tests/templates/index.html
@@ -75,7 +75,7 @@
         <article class="h-entry entry">
         {% block entry scoped %}
         <h2 class="p-name">
-            <a class="u-url" href="{{entry.link}}">{{entry.title or '🗒'}}</a>
+            <a class="u-url" href="{{entry.link}}">{{entry.title or '<code>(no title)</code>'|safe}}</a>
         </h2>
 
         {% block body scoped %}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
fixes #240 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
see tests in `/alias/exceptions.md`

## Got a site to show off?

<!-- If so, link to it here! -->
