### PR TITLE
Add user.token template function, and remove deprecated AutoAuth stuff

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -572,6 +572,20 @@ checkqa-mypy = ["mypy (v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+category = "dev"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+name = "pytest-mock"
+optional = false
+python-versions = ">=3.5"
+version = "3.2.0"
+
+[package.dependencies]
+pytest = ">=2.7"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 category = "main"
 description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
@@ -772,7 +786,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "92deacd41f2eada4f225fc29aa218197181c127cd609bd8e549c30bf486bdd2f"
+content-hash = "b52775c75d0ad8abcfea914259d53d59799a304605fa906502dfaa605daa6f52"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1109,6 +1123,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.2.0.tar.gz", hash = "sha256:7122d55505d5ed5a6f3df940ad174b3f606ecae5e9bc379569cdcbd4cd9d2b83"},
+    {file = "pytest_mock-3.2.0-py3-none-any.whl", hash = "sha256:5564c7cd2569b603f8451ec77928083054d8896046830ca763ed68f4112d17c7"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -14,7 +14,7 @@ import werkzeug.exceptions
 from werkzeug.utils import cached_property
 
 from . import (caching, cli, config, html_entry, image, index, maintenance,
-               model, rendering, tokens, user, utils, view)
+               model, rendering, user, utils, view)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -69,7 +69,6 @@ class Publ(flask.Flask):
             to all entries regardless of permissions
         * ``auth_log_prune_interval``: How frequently to prune the authentication log, in seconds
         * ``auth_log_prune_age``: How long to retain authentication log entries, in seconds
-        * ``max_token_age``: The maximum lifetime of AutoAuth tokens
         """
         # pylint:disable=too-many-branches,too-many-statements
 
@@ -127,8 +126,6 @@ This configuration value will stop being supported in Publ 0.6.
         self.add_url_rule('/_file/<path:filename>',
                           'asset', rendering.retrieve_asset)
 
-        self.add_url_rule('/_token', 'token', tokens.token_endpoint, methods=['POST'])
-
         self.config['TRAP_HTTP_EXCEPTIONS'] = True
         self.register_error_handler(
             werkzeug.exceptions.HTTPException, rendering.render_exception)
@@ -176,7 +173,6 @@ This configuration value will stop being supported in Publ 0.6.
                 self.add_url_rule(route, 'admin', rendering.admin_dashboard)
 
             self.before_request(user.log_user)
-            self.after_request(tokens.inject_auth_headers)
 
             # Force the authl instance to load before the first request, after the
             # app has had a chance to set secret_key

--- a/publ/cli.py
+++ b/publ/cli.py
@@ -37,11 +37,12 @@ def reindex_command(quietly, fresh):
 @publ_cli.command('token', short_help="Generate a bearer token")
 @click.argument('identity')
 @click.option('--scope', '-s', help="The token's permission scope")
+@click.option('--lifetime', '-l', help="The token's lifetime (in seconds)")
 @with_appcontext
-def token_command(identity, scope):
+def token_command(identity, scope, lifetime=3600):
     """ Command to retrieve a bearer token """
     from . import tokens
-    print(tokens.get_token(identity, scope))
+    print(tokens.get_token(identity, int(lifetime), scope))
 
 
 def setup(app):

--- a/publ/config.py
+++ b/publ/config.py
@@ -53,7 +53,6 @@ class _Defaults:
     admin_group = 'admin'
     auth_log_prune_interval = 3600
     auth_log_prune_age = 86400 * 30  # one month
-    max_token_age = 3600
 
 
 class Config(_Defaults):

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -111,7 +111,7 @@ def render_publ_template(template: Template, **kwargs) -> typing.Tuple[str, str]
         }
 
         text = template.render(**args)
-        return text, caching.get_etag(text), flask.g.stash
+        return text, caching.get_etag(text), flask.g.get('needs_auth')
 
     @orm.db_session
     def latest_entry():
@@ -125,8 +125,7 @@ def render_publ_template(template: Template, **kwargs) -> typing.Tuple[str, str]
         return None
 
     try:
-        flask.g.stash = {}
-        text, etag, flask.g.stash = do_render(
+        text, etag, flask.g.needs_auth = do_render(
             template,
             user=user.get_active(),
             _url=request.url,

--- a/publ/user.py
+++ b/publ/user.py
@@ -160,6 +160,10 @@ class User(caching.Memoizable):
         """ Get the latest known active time for the user """
         return arrow.get(self._info[2]).to(config.timezone)
 
+    def token(self, lifetime: int, scope: str = None) -> str:
+        """ Get a bearer token for this user """
+        return tokens.get_token(self.identity, lifetime, scope)
+
 
 @utils.stash
 def get_active() -> typing.Optional[User]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ mypy = "^0.782"
 pylint = "^2.5.3"
 pytest = "^5.4.3"
 isort = "^4"
+pytest-mock = "^3.2.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,7 @@
 """ test framework stuff """
 
+import uuid
+
 import flask
 
 from publ import config
@@ -11,3 +13,4 @@ class PublMock(flask.Flask):
     def __init__(self, cfg: dict = None):
         super().__init__(__name__)
         self.publ_config = config.Config(cfg or {})
+        self.secret_key = uuid.uuid4().bytes

--- a/tests/templates/index.html
+++ b/tests/templates/index.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="style.css" />
     <link rel="alternate" type="application/atom+xml" title="Atom feed" href="feed" />
     <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML' async></script>
-    <link rel="token_endpoint" href="{{token_endpoint}}" />
 </head>
 <body id="{{template.name}}">
 

--- a/tests/templates/userinfo.html
+++ b/tests/templates/userinfo.html
@@ -21,6 +21,8 @@
             {% endfor %}
         </ul></li>
     </ul>
+
+    <p>Auth token test: <code>curl -H 'Authorization: Bearer {{user.token(3600)}}' {{request.url}}</code></p>
     {% else %}
     No active user
     {% endif %}

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,46 @@
+""" Bearer token tests """
+# pylint:disable=missing-docstring
+
+import flask
+import pytest
+import werkzeug.exceptions as http_error
+
+from publ import tokens, user
+
+
+def test_token_flow(mocker):
+    app = flask.Flask(__name__)
+    app.secret_key = 'random bytes'
+    mock_time = mocker.patch('time.time')
+
+    with app.app_context():
+        mock_time.return_value = 100
+        token = tokens.get_token('somebody', 1600)
+
+        parsed = tokens.parse_token(token)
+        assert parsed['me'] == 'somebody'
+        assert 'scope' not in parsed
+
+        mock_time.return_value = 1800
+        with pytest.raises(http_error.Unauthorized):
+            parsed = tokens.parse_token(token)
+
+        token = tokens.get_token('someone', 1600, 'read')
+        parsed = tokens.parse_token(token)
+        assert parsed['me'] == 'someone'
+        assert parsed['scope'] == 'read'
+
+        with pytest.raises(http_error.Unauthorized):
+            parsed = tokens.parse_token('kwijibo')
+
+
+def test_request():
+    app = flask.Flask(__name__)
+
+    with app.test_request_context('/foo'):
+        tokens.request(user.User('moo'))
+        assert 'needs_auth' not in flask.g
+
+    with app.test_request_context('/bar'):
+        tokens.request(None)
+        assert flask.g.needs_auth


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Allows templates to provide a user-visible bearer token; fixes #411 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Reworks how tokens are generated and validated.

Because AutoAuth is dead in the water and the token_endpoint only existed for AutoAuth, all that stuff is removed. The auth upgrade hooks have also been simplified, and are only retained in case we decide to add something else with them, or if AutoAuth comes back someday.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
The `{{token_endpoint}}` template function no longer exists, not that it was ever useful.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added unit tests for generating and parsing tokens

Added `curl` sample to `/userinfo` page on test site, and verified it works.

## Got a site to show off?

<!-- If so, link to it here! -->
