### PR TITLE
Improve the error handling for certain malformed dates and entry IDs

### DIFF
--- a/publ/queries.py
+++ b/publ/queries.py
@@ -191,7 +191,10 @@ def where_entry_date(query, datespec):
 
     datespec -- The date spec to check for, in YYYY[[-]MM[[-]DD]] format
     """
-    date, interval, _ = utils.parse_date(datespec)
+    try:
+        date, interval, _ = utils.parse_date(datespec)
+    except ValueError as error:
+        raise InvalidQueryError(f"Invalid date {datespec}") from error
     start_date, end_date = date.span(interval)
 
     return query.filter(lambda e:
@@ -230,9 +233,12 @@ def get_entry(entry):
         return getattr(entry, '_record')
 
     if isinstance(entry, (int, str)):
-        return model.Entry.get(id=int(entry))
+        try:
+            return model.Entry.get(id=int(entry))
+        except ValueError as error:
+            raise InvalidQueryError(f"Invalid entry ID {entry}") from error
 
-    raise ValueError(f"entry is of unknown type {type(entry)}")
+    raise InvalidQueryError(f"entry is of unknown type {type(entry)}")
 
 
 def build_query(spec):

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -305,12 +305,14 @@ def render_category_path(category: str, template: typing.Optional[str]):
         # nope, we just don't know what this is
         raise http_error.NotFound(f"No such view '{template}'")
 
+    view_spec = view.parse_view_spec(request.args)
+    view_spec['category'] = category
     try:
-        view_spec = view.parse_view_spec(request.args)
-        view_spec['category'] = category
         view_obj = view.View.load(view_spec)
     except arrow.parser.ParserError as error:
         raise http_error.BadRequest("Invalid date") from error
+    except queries.InvalidQueryError as err:
+        raise http_error.BadRequest(str(err))
 
     rendered, etag = render_publ_template(
         tmpl,


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Improves the way that errors get handled in certain malformed URL scenarios; a better fix for #416 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
b98271c fixed some of the most egregious 500 ISEs but there were still plenty coming through from certain badly-behaving robots; for example, URLs like `/?date=2010070` and `/?id=asdf` were passing the view validator but still causing exceptions in the query generator.

Now the query generator catches those underlying exceptions and promotes them to `InvalidQueryError`, which in turn gets handled as a `400 Bad Request`.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
