### PR TITLE
Add global layout configuration

### DIFF
--- a/publ/config.py
+++ b/publ/config.py
@@ -37,6 +37,7 @@ class _Defaults:
 
     # Page rendering
     cache: typing.Dict[str, str] = {}
+    layout: typing.Dict[str, typing.Any] = {}
     markdown_extensions = (
         'tables',
         'fenced-code',

--- a/publ/image/external.py
+++ b/publ/image/external.py
@@ -66,10 +66,8 @@ class ExternalImage(Image):
 
             if width:
                 attrs['width'] = width
-                style_parts.append(f'width:{width}px')
             if height:
                 attrs['height'] = height
-                style_parts.append(f'height:{height}px')
             if max_width:
                 style_parts.append(f'max-width:{max_width}px')
             if max_height:

--- a/publ/image/external.py
+++ b/publ/image/external.py
@@ -38,9 +38,9 @@ class ExternalImage(Image):
         if not spec.get('_no_resize_external'):
             # try to fudge the sizing
             max_width = spec.get('max_width')
-            width = spec.get('width') or max_width
+            width = spec.get('width')
             max_height = spec.get('max_height')
-            height = spec.get('height') or max_height
+            height = spec.get('height')
             size_mode = spec.get('resize', 'fit')
 
             if width and max_width and max_width < width:
@@ -66,8 +66,14 @@ class ExternalImage(Image):
 
             if width:
                 attrs['width'] = width
+                style_parts.append(f'width:{width}px')
             if height:
                 attrs['height'] = height
+                style_parts.append(f'height:{height}px')
+            if max_width:
+                style_parts.append(f'max-width:{max_width}px')
+            if max_height:
+                style_parts.append(f'max-height:{max_height}px')
 
         return attrs
 

--- a/publ/image/image.py
+++ b/publ/image/image.py
@@ -47,13 +47,13 @@ class Image(ABC):
     def _filename(self) -> str:
         """ Get the filename of the file, for default alt text purposes """
 
-    def get_img_attrs(self, **kwargs) -> utils.TagAttrs:
+    def get_img_attrs(self, params:dict) -> utils.TagAttrs:
         """ Get an attribute list (src, style, et al) for the image.
 
         Returns: a dict of attributes e.g. {'src':'foo.jpg','srcset':'foo.jpg 1x, bar.jpg 2x']
         """
 
-        params = utils.prefix_normalize(kwargs)
+        params = utils.prefix_normalize(params)
 
         styles: typing.List[str] = []
         attrs = self._get_img_attrs(params, styles)
@@ -92,7 +92,7 @@ class Image(ABC):
 
         try:
             attrs = {
-                **self.get_img_attrs(**kwargs)
+                **self.get_img_attrs(kwargs)
             }
 
             if alt_text:

--- a/publ/image/image.py
+++ b/publ/image/image.py
@@ -47,7 +47,7 @@ class Image(ABC):
     def _filename(self) -> str:
         """ Get the filename of the file, for default alt text purposes """
 
-    def get_img_attrs(self, params:dict) -> utils.TagAttrs:
+    def get_img_attrs(self, params: dict) -> utils.TagAttrs:
         """ Get an attribute list (src, style, et al) for the image.
 
         Returns: a dict of attributes e.g. {'src':'foo.jpg','srcset':'foo.jpg 1x, bar.jpg 2x']

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -525,7 +525,7 @@ def to_html(text, args, search_path,
     tocs: TocBuffer = toc_buffer if toc_buffer is not None else []
 
     # first process as Markdown
-    renderer = HtmlRenderer(args,
+    renderer = HtmlRenderer({**config.layout, **args},
                             search_path,
                             toc_buffer=tocs,
                             footnote_buffer=footnotes,

--- a/test_app.py
+++ b/test_app.py
@@ -46,6 +46,9 @@ config = {
         'EMAIL_CHECK_MESSAGE': 'Use the link printed to the test console',
     },
     'user_list': os.path.join(APP_PATH, 'users.cfg'),
+    'layout': {
+        'max_width': 768,
+    }
 }
 
 app = publ.Publ(__name__, config)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,7 +10,7 @@ from publ import config
 class PublMock(flask.Flask):
     """ A mock class for a Publ app """
 
-    def __init__(self, cfg: dict = None):
-        super().__init__(__name__)
+    def __init__(self, cfg: dict = None, **kwargs):
+        super().__init__(__name__, **kwargs)
         self.publ_config = config.Config(cfg or {})
         self.secret_key = uuid.uuid4().bytes

--- a/tests/content/images/html renditions.html
+++ b/tests/content/images/html renditions.html
@@ -3,9 +3,21 @@ Date: 2020-01-04 00:42:19-08:00
 Entry-ID: 2174
 UUID: b95a3bf1-a110-5c33-b41a-78a4e0c57bfb
 
-tests of how parse failures affect HTML entries
+tests of image renditions in HTML entries
 
 .....
+
+<h2>local images</h2>
+
+<img src="rawr.jpg" title="unsized">
+
+<img src="Landscape_1.jpg" title="unsized">
+
+<img src="Landscape_1.jpg" width=1024 title="width set above max width">
+
+<img src="Landscape_1.jpg{max_width=None}"  title="max_width overridden">
+
+<h2>parse failures</h2>
 
 <img src="not found.jpg" title="file not found">
 

--- a/tests/test_html_entry.py
+++ b/tests/test_html_entry.py
@@ -1,6 +1,8 @@
 """ tests of publ.html_entry module """
 # pylint:disable=missing-function-docstring
 
+from . import PublMock
+
 
 def test_process_passthrough():
     from publ.html_entry import process


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Adds the ability to globally configure the default layout settings for `entry.body`/`entry.more`/etc.

Closes #424 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

The configuration object now takes an additional dict, `layout`, which provides defaults for layout methods. For example,

```
app = publ.Publ(name, {
    'layout': {
        'max_width': 768,
        'max_height': 1024
    }
})
```

Additionally, some fixes were made to how default attributes get applied to pure-HTML entries, and external images now use CSS to specify the container size instead of always applying max_width to the `width` attribute.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Added a global `max_width` default of 768 to the test app, and verified that all of the larger-than-768xwhatever images were clamped to 768xwhatever, and that it could be overridden on a per-image basis if needed.

## Got a site to show off?

<!-- If so, link to it here! -->
