### PR TITLE
Don't display hidden-tag tags in category.tags

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -245,9 +245,9 @@ class Category(caching.Memoizable):
         """
         def _tags(**spec) -> typing.List[TagCount]:
             entries = self._entries(spec)
-            tags = orm.select((tag.name, orm.count(tag.key, distinct=False))
-                              for e in entries for tag in e.tags)
-            return [TagCount(key, count) for (key, count) in tags]
+            etags = orm.select((tag.tag, orm.count(tag.tag, distinct=False))
+                               for e in entries for tag in e.tags if not tag.hidden)
+            return [TagCount(tag.name, count) for (tag, count) in etags]
         return utils.CallableProxy(_tags)
 
     def __getattr__(self, name):

--- a/publ/model.py
+++ b/publ/model.py
@@ -16,7 +16,7 @@ DbEntity: orm.core.Entity = db.Entity
 LOGGER = logging.getLogger(__name__)
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 17
+SCHEMA_VERSION = 18
 
 
 class GlobalConfig(DbEntity):
@@ -84,7 +84,7 @@ class Entry(DbEntity):
     sort_title = orm.Optional(str)
 
     aliases = orm.Set("PathAlias")
-    tags = orm.Set("EntryTag")
+    tags = orm.Set("EntryTagged")
 
     auth = orm.Set("EntryAuth")
     auth_log = orm.Set("AuthLog")
@@ -134,11 +134,21 @@ class Entry(DbEntity):
 
 
 class EntryTag(DbEntity):
-    """ Tags for an entry """
+    """ Tags available for entries """
     key = orm.PrimaryKey(str)
     name = orm.Required(str)
 
-    entries = orm.Set(Entry)
+    entries = orm.Set("EntryTagged")
+
+
+class EntryTagged(DbEntity):
+    """ Actual tag membership for entries """
+    entry = orm.Required(Entry)
+    tag = orm.Required(EntryTag)
+    hidden = orm.Required(bool)
+
+    orm.composite_key(entry, tag)
+    orm.composite_key(tag, entry)
 
 
 class Category(DbEntity):

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -168,19 +168,23 @@ def where_entry_type_not(query, entry_type):
 
 def where_entry_tag(query, tags, operation: FilterCombiner):
     """ Generate a where clause for entries with the given tags """
-    tags = [t.lower() for t in utils.as_list(tags)]
+    tags = [t.key if isinstance(t, model.EntryTag) else t.casefold()
+            for t in utils.as_list(tags)]
 
     if operation == FilterCombiner.ANY:
-        return query.filter(lambda e: orm.exists(t for t in e.tags if t.key in tags))
+        return query.filter(lambda e: orm.exists(t for t in e.tags
+                                                 if t.tag.key in tags))
 
     if operation == FilterCombiner.ALL:
         for tag in tags:
-            query = query.filter(lambda e: orm.exists(t for t in e.tags if t.key == tag))
+            query = query.filter(lambda e: orm.exists(t for t in e.tags
+                                                      if t.tag.key == tag))
         return query
 
     if operation == FilterCombiner.NONE:
         for tag in tags:
-            query = query.filter(lambda e: not orm.exists(t for t in e.tags if t.key == tag))
+            query = query.filter(lambda e: not orm.exists(t for t in e.tags
+                                                          if t.tag.key == tag))
         return query
 
     raise InvalidQueryError("Unsupported FilterCombiner " + str(operation))

--- a/publ/view.py
+++ b/publ/view.py
@@ -332,9 +332,9 @@ class View(caching.Memoizable):
                             raise ValueError(f"key {k} is of type {type(val)}")
                         break
 
-            taglist = self.spec.get('tag')
+            taglist = kwargs.get('tag', self.spec.get('tag'))
             if taglist:
-                args['tag'] = taglist if isinstance(taglist, str) else list(taglist)
+                args['tag'] = list(utils.TagSet(utils.as_list(taglist)).keys())
 
             return flask.url_for('category',
                                  **args,

--- a/tests/content/tags/tag1.md
+++ b/tests/content/tags/tag1.md
@@ -1,6 +1,7 @@
 Title: Tagged entry
 Tag: Foo
 Tag: moo
+Hidden-Tag: always-hidden
 Entry-ID: 305
 UUID: ec0ad5cf-3a2e-584f-892b-1c3d7a58af01
 Date: 2019-03-03 22:45:47-08:00

--- a/tests/content/tags/tag2.md
+++ b/tests/content/tags/tag2.md
@@ -1,6 +1,7 @@
 Title: Tagged entry 2
 Tag: hello
 Tag: bar
+Hidden-Tag: always-hidden
 UUID: ec0ad5cf-3a2e-584f-892b-1c3d7a58af01
 Entry-ID: 665
 Date: 2019-03-03 22:45:49-08:00

--- a/tests/content/tags/tag3.md
+++ b/tests/content/tags/tag3.md
@@ -1,5 +1,6 @@
 Title: Tagged entry 3
 Tag: hello
+Hidden-Tag: always-hidden
 Tag: foo
 UUID: ec0ad5cf-3a2e-584f-892b-1c3d7a58af01
 Entry-ID: 454

--- a/tests/templates/tags/index.html
+++ b/tests/templates/tags/index.html
@@ -28,7 +28,7 @@
 <ul>
 {% for entry in view(recurse=True,tag_filter=filter).entries %}
 <li><a href="{{entry.link}}">{{entry.title}}</a>: <ul>
-    {% for tag in entry.get_all('Tag') %}
+    {% for tag in entry.tags %}
     <li><a href="{{view.tag_add(tag).link}}">{{ tag }}</a> (<a href="{{view.tag_toggle(tag).link}}">T</a>)</li>
     {% endfor %}
 </ul></li>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Hide `Hidden-Tag` from category tag browsing; closes #401 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

There is now a proxy object `EntryTagged` which tracks the actual entry placement in tags, and tracks whether the tag was hidden or not, and all of the queries have been updated accordingly.

This also does some more normalization on how tags are handled on view specs and `category.archive`, so they are now always case-folded and frozenset-ordered in URLs.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

See the tests in `tags`, including the `always-hidden` tag which is always hidden (and thus doesn't appear in the category browser at all).

## Got a site to show off?

<!-- If so, link to it here! -->
