### PR TITLE
Improve tag normalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ preflight:
 
 .PHONY: test
 test:
+	FLASK_APP=test_app.py poetry run flask publ reindex
 	poetry run coverage run -m pytest -Werror
 
 .PHONY: cov

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -858,7 +858,7 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], fixup_pass: int) -> 
 
     with orm.db_session:
         set_tags = {
-            t[0].casefold(): t
+            utils.TagKey(t[0]): t
             for t in [(k, True) for k in entry.get_all('Hidden-Tag', [])]
             + [(k, False) for k in entry.get_all('Tag', [])]
         }
@@ -886,7 +886,7 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], fixup_pass: int) -> 
             if not tag_record:
                 LOGGER.debug("creating tag %s/%s", key, name)
                 tag_record = model.EntryTag(key=key, name=name)
-            elif name != tag_record.name and not name.islower() and not hidden:
+            elif name != tag_record.name and name != key and not hidden:
                 LOGGER.debug("updating tag name %s/%s -> %s",
                              key, tag_record.name, name)
                 tag_record.name = name

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -858,7 +858,7 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], fixup_pass: int) -> 
 
     with orm.db_session:
         set_tags = {
-            utils.TagKey(t[0]): t
+            utils.tag_key(t[0]): t
             for t in [(k, True) for k in entry.get_all('Hidden-Tag', [])]
             + [(k, False) for k in entry.get_all('Tag', [])]
         }

--- a/publ/model.py
+++ b/publ/model.py
@@ -16,7 +16,7 @@ DbEntity: orm.core.Entity = db.Entity
 LOGGER = logging.getLogger(__name__)
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 
 
 class GlobalConfig(DbEntity):

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -168,7 +168,7 @@ def where_entry_type_not(query, entry_type):
 
 def where_entry_tag(query, tags, operation: FilterCombiner):
     """ Generate a where clause for entries with the given tags """
-    tags = [t.key if isinstance(t, model.EntryTag) else t.casefold()
+    tags = [t.key if isinstance(t, model.EntryTag) else utils.TagKey(t)
             for t in utils.as_list(tags)]
 
     if operation == FilterCombiner.ANY:

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -168,8 +168,7 @@ def where_entry_type_not(query, entry_type):
 
 def where_entry_tag(query, tags, operation: FilterCombiner):
     """ Generate a where clause for entries with the given tags """
-    tags = [t.key if isinstance(t, model.EntryTag) else utils.TagKey(t)
-            for t in utils.as_list(tags)]
+    tags = [utils.tag_key(t) for t in utils.as_list(tags)]
 
     if operation == FilterCombiner.ANY:
         return query.filter(lambda e: orm.exists(t for t in e.tags

--- a/tests/content/tags/multiple.md
+++ b/tests/content/tags/multiple.md
@@ -3,6 +3,7 @@ Tag: foo
 Tag: foo
 Tag: Foo
 Hidden-tag: Foo
+Tag: Foo
 Date: 2019-03-18 11:18:49-07:00
 Entry-ID: 734
 UUID: 1acda226-9ac8-5bfa-b5dc-5447042b5d5e

--- a/tests/content/tags/normalization.md
+++ b/tests/content/tags/normalization.md
@@ -1,0 +1,10 @@
+Title: Tag normalization
+Tag: foo™
+tag: 猫
+Tag: ねこ
+tag: にゃこま
+Date: 2021-01-10 13:40:34-08:00
+Entry-ID: 116
+UUID: 420a8598-5b81-5d52-b316-f976ac6073a0
+
+Some tags which should get normalized into ascii in different ways

--- a/tests/content/tags/normalized.md
+++ b/tests/content/tags/normalized.md
@@ -1,0 +1,9 @@
+Title: Tags normalized
+Tag: foo  tm
+tag: mao
+Tag: neko
+tag: niyakoma
+Date: 2021-01-10 13:41:50-08:00
+Entry-ID: 1748
+UUID: bb4f6a6d-99de-5b4f-a210-5b6ff363cb0d
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -150,16 +150,16 @@ def test_tagset_membership(mocker):
         assert item in tags
         assert item.lower() in tags
         assert item.upper() in tags
-        assert utils.TagKey(item) in tags
+        assert utils.tag_key(item) in tags
 
     for item in tags:
-        assert utils.TagKey(item) in {utils.TagKey(t) for t in items}
+        assert utils.tag_key(item) in {utils.tag_key(t) for t in items}
 
     for item in others:
         assert item not in tags
         assert item.lower() not in tags
         assert item.upper() not in tags
-        assert utils.TagKey(item) not in tags
+        assert utils.tag_key(item) not in tags
 
 
 def test_tagset_operators(mocker):


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Improve the way that tags are normalized and displayed.

Fixes #430. Fixes #431 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

When tags are stored in the database, they use the slugified form of the tag name, instead of simply casefolding it. This way, tags such as `neko` and `ねこ` are treated equivalently, and punctuation is also folded away (e.g. `dance dance revolve` and `dance, dance, revolve` are also equivalent). This has the side effect of also making view URLs always 7-bit-clean, albeit in a reductively Anglicizing way.

When tags are displayed from `view.tags` (or anything else which is processed through `utils.TagSet`), it now consults the database for the display name of the tag. This uses the most recently-indexed denormalization of the tag.

This does *not* change the display of tags in `entry.tags` (by design).