### PR TITLE
Implement Ticket Auth

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -437,7 +437,7 @@ pyparsing = ">=2.0.2"
 
 [[package]]
 name = "pillow"
-version = "8.3.0"
+version = "8.3.1"
 description = "Python Imaging Library (Fork)"
 category = "main"
 optional = false
@@ -619,6 +619,22 @@ security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
+name = "requests-mock"
+version = "1.9.3"
+description = "Mock out responses from the requests package"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+requests = ">=2.3,<3"
+six = "*"
+
+[package.extras]
+fixture = ["fixtures"]
+test = ["fixtures", "mock", "purl", "pytest", "sphinx", "testrepository (>=0.0.18)", "testtools"]
+
+[[package]]
 name = "requests-oauthlib"
 version = "1.3.0"
 description = "OAuthlib authentication support for Requests."
@@ -772,7 +788,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "6389ddfaf8289108a79f46f83abf11a38fc945a5ee093ba71a5e82f85eaacc79"
+content-hash = "9dbe1efd25d7b788ad5455b81e97421cb92c64056674b13c1ea9b907acfa1b4b"
 
 [metadata.files]
 arrow = [
@@ -1070,40 +1086,40 @@ packaging = [
     {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
 ]
 pillow = [
-    {file = "Pillow-8.3.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:333313bcc53a8a7359e98d5458dfe37bfa301da2fd0e0dc41f585ae0cede9181"},
-    {file = "Pillow-8.3.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bccd0d604d814e9494f3bf3f077a23835580ed1743c5175581882e7dd1f178c3"},
-    {file = "Pillow-8.3.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7beda44f177ee602aa27e0a297da1657d9572679522c8fb8b336b734653516e"},
-    {file = "Pillow-8.3.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:94db5ea640330de0945b41dc77fb4847b4ab6e87149126c71b36b112e8400898"},
-    {file = "Pillow-8.3.0-cp36-cp36m-win32.whl", hash = "sha256:856fcbc3201a6cabf0478daa0c0a1a8a175af7e5173e2084ddb91cc707a09dd1"},
-    {file = "Pillow-8.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:34ce3d993cb4ca840b1e31165b38cb19c64f64f822a8bc5565bde084baff3bdb"},
-    {file = "Pillow-8.3.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:778a819c2d194e08d39d67ddb15ef0d32eba17bf7d0c2773e97bd221b2613a3e"},
-    {file = "Pillow-8.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b42ea77f4e7374a67e1f27aaa9c62627dff681f67890e5b8f0c1e21b1500d9d2"},
-    {file = "Pillow-8.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:53f6e4b73b3899015ac4aa95d99da0f48ea18a6d7c8db672e8bead3fb9570ef5"},
-    {file = "Pillow-8.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fb91deb5121b6dde88599bcb3db3fdad9cf33ff3d4ccc5329ee1fe9655a2f7ff"},
-    {file = "Pillow-8.3.0-cp37-cp37m-win32.whl", hash = "sha256:8f65d2a98f198e904dbe89ecb10862d5f0511367d823689039e17c4d011de11e"},
-    {file = "Pillow-8.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:25f6564df21d15bcac142b4ed92b6c02e53557539f535f31c1f3bcc985484753"},
-    {file = "Pillow-8.3.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:c2d78c8230bda5fc9f6b1d457c7f8f3432f4fe85bed86f80ba3ed73d59775a88"},
-    {file = "Pillow-8.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:950e873ceefbd283cbe7bc5b648b832d1dcf89eeded6726ebec42bc7d67966c0"},
-    {file = "Pillow-8.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1037288a22cc8ec9d2918a24ded733a1cc4342fd7f21d15d37e6bbe5fb4a7306"},
-    {file = "Pillow-8.3.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:063d17a02a0170c2f880fbd373b2738b089c6adcbd1f7418667bc9e97524c11b"},
-    {file = "Pillow-8.3.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:561339ed7c324bbcb29b5e4f4705c97df950785394b3ac181f5bf6a08088a672"},
-    {file = "Pillow-8.3.0-cp38-cp38-win32.whl", hash = "sha256:331f8321418682386e4f0d0e6369f732053f95abddd2af4e1b1ef74a9537ef37"},
-    {file = "Pillow-8.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:eccaefbd646022b5313ca4b0c5f1ae6e0d3a52ef66de64970ecf3f9b2a1be751"},
-    {file = "Pillow-8.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:6f7517a220aca8b822e25b08b0df9546701a606a328da5bc057e5f32a3f9b07c"},
-    {file = "Pillow-8.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cc8e926d6ffa65d0dddb871b7afe117f17bc045951e66afde60eb0eba923db9e"},
-    {file = "Pillow-8.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:519b3b24dedc81876d893475bade1b92c4ce7c24b9b82224f0bd8daae682e039"},
-    {file = "Pillow-8.3.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:72858a27dd7bd1c40f91c4f85db3b9f121c8412fd66573121febb00d074d0530"},
-    {file = "Pillow-8.3.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:3251557c53c1ed0c345559afc02d2b0a0aa5788042e161366ed90b27bc322d3d"},
-    {file = "Pillow-8.3.0-cp39-cp39-win32.whl", hash = "sha256:ce90aad0a3dc0f13a9ff0ab1f43bcbea436089b83c3fadbe37c6f1733b938bf1"},
-    {file = "Pillow-8.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:490c9236ef4762733b6c2e1f1fcb37793cb9c57d860aa84d6994c990461882e5"},
-    {file = "Pillow-8.3.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:aef0838f28328523e9e5f2c1852dd96fb85768deb0eb8f908c54dad0f44d2f6f"},
-    {file = "Pillow-8.3.0-pp36-pypy36_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:713b762892efa8cd5d8dac24d16ac2d2dbf981963ed1b3297e79755f03f8cbb8"},
-    {file = "Pillow-8.3.0-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cec702974f162026bf8de47f6f4b7ce9584a63c50002b38f195ee797165fea77"},
-    {file = "Pillow-8.3.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:d9ef8119ce44f90d2f8ac7c58f7da480ada5151f217dc8da03681b73fc91dec3"},
-    {file = "Pillow-8.3.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fc25d59ecf23ea19571065306806a29c43c67f830f0e8a121303916ba257f484"},
-    {file = "Pillow-8.3.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:28f184c0a65be098af412f78b0b6f3bbafd1614e1dc896e810d8357342a794b7"},
-    {file = "Pillow-8.3.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:c3529fb98a40f89269175442c5ff4ef81d22e91b2bdcbd33833a350709b5130c"},
-    {file = "Pillow-8.3.0.tar.gz", hash = "sha256:803606e206f3e366eea46b1e7ab4dac74cfac770d04de9c35319814e11e47c46"},
+    {file = "Pillow-8.3.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:196560dba4da7a72c5e7085fccc5938ab4075fd37fe8b5468869724109812edd"},
+    {file = "Pillow-8.3.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c9569049d04aaacd690573a0398dbd8e0bf0255684fee512b413c2142ab723"},
+    {file = "Pillow-8.3.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c088a000dfdd88c184cc7271bfac8c5b82d9efa8637cd2b68183771e3cf56f04"},
+    {file = "Pillow-8.3.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fc214a6b75d2e0ea7745488da7da3c381f41790812988c7a92345978414fad37"},
+    {file = "Pillow-8.3.1-cp36-cp36m-win32.whl", hash = "sha256:a17ca41f45cf78c2216ebfab03add7cc350c305c38ff34ef4eef66b7d76c5229"},
+    {file = "Pillow-8.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:67b3666b544b953a2777cb3f5a922e991be73ab32635666ee72e05876b8a92de"},
+    {file = "Pillow-8.3.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:ff04c373477723430dce2e9d024c708a047d44cf17166bf16e604b379bf0ca14"},
+    {file = "Pillow-8.3.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9364c81b252d8348e9cc0cb63e856b8f7c1b340caba6ee7a7a65c968312f7dab"},
+    {file = "Pillow-8.3.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a2f381932dca2cf775811a008aa3027671ace723b7a38838045b1aee8669fdcf"},
+    {file = "Pillow-8.3.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d0da39795049a9afcaadec532e7b669b5ebbb2a9134576ebcc15dd5bdae33cc0"},
+    {file = "Pillow-8.3.1-cp37-cp37m-win32.whl", hash = "sha256:2b6dfa068a8b6137da34a4936f5a816aba0ecc967af2feeb32c4393ddd671cba"},
+    {file = "Pillow-8.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a4eef1ff2d62676deabf076f963eda4da34b51bc0517c70239fafed1d5b51500"},
+    {file = "Pillow-8.3.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:660a87085925c61a0dcc80efb967512ac34dbb256ff7dd2b9b4ee8dbdab58cf4"},
+    {file = "Pillow-8.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:15a2808e269a1cf2131930183dcc0419bc77bb73eb54285dde2706ac9939fa8e"},
+    {file = "Pillow-8.3.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:969cc558cca859cadf24f890fc009e1bce7d7d0386ba7c0478641a60199adf79"},
+    {file = "Pillow-8.3.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ee77c14a0299d0541d26f3d8500bb57e081233e3fa915fa35abd02c51fa7fae"},
+    {file = "Pillow-8.3.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c11003197f908878164f0e6da15fce22373ac3fc320cda8c9d16e6bba105b844"},
+    {file = "Pillow-8.3.1-cp38-cp38-win32.whl", hash = "sha256:3f08bd8d785204149b5b33e3b5f0ebbfe2190ea58d1a051c578e29e39bfd2367"},
+    {file = "Pillow-8.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:70af7d222df0ff81a2da601fab42decb009dc721545ed78549cb96e3a1c5f0c8"},
+    {file = "Pillow-8.3.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:37730f6e68bdc6a3f02d2079c34c532330d206429f3cee651aab6b66839a9f0e"},
+    {file = "Pillow-8.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4bc3c7ef940eeb200ca65bd83005eb3aae8083d47e8fcbf5f0943baa50726856"},
+    {file = "Pillow-8.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c35d09db702f4185ba22bb33ef1751ad49c266534339a5cebeb5159d364f6f82"},
+    {file = "Pillow-8.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0b2efa07f69dc395d95bb9ef3299f4ca29bcb2157dc615bae0b42c3c20668ffc"},
+    {file = "Pillow-8.3.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cc866706d56bd3a7dbf8bac8660c6f6462f2f2b8a49add2ba617bc0c54473d83"},
+    {file = "Pillow-8.3.1-cp39-cp39-win32.whl", hash = "sha256:9a211b663cf2314edbdb4cf897beeb5c9ee3810d1d53f0e423f06d6ebbf9cd5d"},
+    {file = "Pillow-8.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:c2a5ff58751670292b406b9f06e07ed1446a4b13ffced6b6cab75b857485cbc8"},
+    {file = "Pillow-8.3.1-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:c379425c2707078dfb6bfad2430728831d399dc95a7deeb92015eb4c92345eaf"},
+    {file = "Pillow-8.3.1-pp36-pypy36_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:114f816e4f73f9ec06997b2fde81a92cbf0777c9e8f462005550eed6bae57e63"},
+    {file = "Pillow-8.3.1-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8960a8a9f4598974e4c2aeb1bff9bdd5db03ee65fd1fce8adf3223721aa2a636"},
+    {file = "Pillow-8.3.1-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:147bd9e71fb9dcf08357b4d530b5167941e222a6fd21f869c7911bac40b9994d"},
+    {file = "Pillow-8.3.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1fd5066cd343b5db88c048d971994e56b296868766e461b82fa4e22498f34d77"},
+    {file = "Pillow-8.3.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f4ebde71785f8bceb39dcd1e7f06bcc5d5c3cf48b9f69ab52636309387b097c8"},
+    {file = "Pillow-8.3.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:1c03e24be975e2afe70dfc5da6f187eea0b49a68bb2b69db0f30a61b7031cee4"},
+    {file = "Pillow-8.3.1.tar.gz", hash = "sha256:2cac53839bfc5cece8fdbe7f084d5e3ee61e1303cccc86511d351adcb9e2c792"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -1206,6 +1222,10 @@ regex = [
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+requests-mock = [
+    {file = "requests-mock-1.9.3.tar.gz", hash = "sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba"},
+    {file = "requests_mock-1.9.3-py2.py3-none-any.whl", hash = "sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970"},
 ]
 requests-oauthlib = [
     {file = "requests-oauthlib-1.3.0.tar.gz", hash = "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a"},

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -179,6 +179,15 @@ This configuration value will stop being supported in Publ 0.6.
 
             self.before_request(user.log_user)
 
+            def add_token_endpoint(response):
+                endpoint = utils.secure_link("tokens", _external=True)
+                response.headers.add(
+                    'Link',
+                    f'<{endpoint}>; rel="token_endpoint"')
+                return response
+
+            self.after_request(add_token_endpoint)
+
             # Force the authl instance to load before the first request, after the
             # app has had a chance to set secret_key
             self.before_first_request(lambda: self.authl)

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -14,7 +14,7 @@ import werkzeug.exceptions
 from werkzeug.utils import cached_property
 
 from . import (caching, cli, config, html_entry, image, index, maintenance,
-               model, rendering, search, user, utils, view)
+               model, rendering, search, tokens, user, utils, view)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -69,6 +69,8 @@ class Publ(flask.Flask):
             to all entries regardless of permissions
         * ``auth_log_prune_interval``: How frequently to prune the authentication log, in seconds
         * ``auth_log_prune_age``: How long to retain authentication log entries, in seconds
+        * ``ticket_lifetime``: How long an IndieAuth ticket lasts, in seconds
+        * ``token_lifetime``: How long an IndieAuth token lasts, in seconds
         """
         # pylint:disable=too-many-branches,too-many-statements
 
@@ -137,7 +139,7 @@ This configuration value will stop being supported in Publ 0.6.
             get_template=rendering.get_template,
             login=utils.auth_link('login'),
             logout=utils.auth_link('logout'),
-            token_endpoint=utils.CallableProxy(lambda: utils.secure_link('token')),
+            token_endpoint=utils.CallableProxy(lambda: utils.secure_link('tokens')),
             secure_url=utils.secure_link,
         )
 
@@ -171,6 +173,9 @@ This configuration value will stop being supported in Publ 0.6.
                     '/_admin/<by>'
             ]:
                 self.add_url_rule(route, 'admin', rendering.admin_dashboard)
+
+            self.add_url_rule('/_tokens', 'tokens', tokens.indieauth_endpoint,
+                              methods=['GET', 'POST'])
 
             self.before_request(user.log_user)
 

--- a/publ/config.py
+++ b/publ/config.py
@@ -54,6 +54,8 @@ class _Defaults:
     admin_group = 'admin'
     auth_log_prune_interval = 3600
     auth_log_prune_age = 86400 * 30  # one month
+    ticket_lifetime = 60
+    token_lifetime = 86400 * 30
 
     # Full-text search directory
     search_index = None

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -1,12 +1,16 @@
 """ IndieAuth token endpoint """
 
+import json
 import logging
 import time
 import typing
 
 import flask
 import itsdangerous
+import requests
 import werkzeug.exceptions as http_error
+
+from .config import config
 
 LOGGER = logging.getLogger(__name__)
 
@@ -17,11 +21,9 @@ def signer():
 
 
 def get_token(id_url: str, lifetime: int, scope: str = None) -> str:
-    """ Gets a signed token for the given identity and scope """
-    token = {
-        'me': id_url
-    }
-    if scope is not None:
+    """ Gets a signed token for the given identity"""
+    token = {'me': id_url}
+    if scope:
         token['scope'] = scope
 
     return signer().dumps((token, int(time.time() + lifetime)))
@@ -48,10 +50,99 @@ def request(user):
     """ Called whenever an authenticated access fails; marks authentication
     as being upgradeable.
 
-    This was added for the purpose of supporting AutoAuth, but with the death
-    of that initiative the token_endpoint stuff was removed. This functionality
-    thus stays around as a just-in-case for later.
+    Currently this is unused by Publ itself, but a site can make use of it to
+    e.g. add a ``WWW-Authenticate`` header or the like in a post-request hook.
     """
 
     if not user:
         flask.g.needs_auth = True
+
+
+def send_auth_ticket(subject: str,
+                     resource: str,
+                     endpoint: str,
+                     scope: str = None):
+    """ Initiate the TicketAuth flow """
+
+    def _submit():
+        scopes = set(scope.split() if scope else [])
+        scopes.add('ticket')
+        ticket = get_token(subject, config.ticket_lifetime, ' '.join(scopes))
+
+        req = requests.post(endpoint, data={
+            'ticket': ticket,
+            'resource': resource,
+            'subject': subject
+        })
+        LOGGER.info("Auth ticket sent to %s for %s: %d %s",
+                    endpoint, subject, req.status_code, req.text)
+
+    # Use the indexer's threadpool to issue the ticket in the background
+    flask.current_app.indexer.submit(_submit)
+
+
+def indieauth_endpoint():
+    """ IndieAuth token endpoint """
+    import authl.handlers.indieauth
+
+    if 'me' in flask.request.args:
+        # A ticket request is being made
+        me_url = flask.request.args['me']
+        try:
+            endpoint, _ = authl.handlers.indieauth.find_endpoint(me_url,
+                                                                 rel='ticket_endpoint')
+        except RuntimeError:
+            endpoint = None
+        if not endpoint:
+            raise http_error.BadRequest("Could not get ticket endpoint")
+        LOGGER.info("endpoint: %s", endpoint)
+        send_auth_ticket(me_url, flask.request.url_root, endpoint)
+        return "Ticket sent", 202
+
+    if 'grant_type' in flask.request.form:
+        # token grant
+        if flask.request.form['grant_type'] == 'ticket':
+            # TicketAuth
+            if 'ticket' not in flask.request.form:
+                raise http_error.BadRequest("Missing ticket")
+
+            ticket = parse_token(flask.request.form['ticket'])
+            LOGGER.info("Redeeming ticket for %s; scopes=%s", ticket['me'],
+                ticket['scope'])
+
+            scopes = set(ticket.get('scope', '').split())
+            if 'ticket' not in scopes:
+                raise http_error.BadRequest("Missing 'ticket' scope")
+
+            scopes.remove('ticket')
+            scope = ' '.join(scopes)
+
+            token = get_token(ticket['me'], config.token_lifetime, scope)
+            response = {
+                'access_token': token,
+                'token_type': 'Bearer',
+                'me': ticket['me'],
+                'expires_in': config.token_lifetime,
+                'refresh_token': get_token(ticket['me'],
+                                           config.token_lifetime,
+                                           ticket['scope'])
+            }
+            if scope:
+                response['scope'] = scope
+
+            return json.dumps(response), {'Content-Type': 'application/json'}
+
+        raise http_error.BadRequest("Unknown grant type")
+
+    if 'action' in flask.request.form:
+        raise http_error.BadRequest()
+
+    if 'Authorization' in flask.request.headers:
+        # ticket verification
+        parts = flask.request.headers['Authorization'].split()
+        if parts[0].lower() == 'bearer':
+            token = parse_token(parts[1])
+            return json.dumps(token), {'Content-Type': 'application/json'}
+        raise http_error.Unauthorized("Invalid authorization header")
+
+    raise http_error.BadRequest()

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -108,7 +108,7 @@ def indieauth_endpoint():
 
             ticket = parse_token(flask.request.form['ticket'])
             LOGGER.info("Redeeming ticket for %s; scopes=%s", ticket['me'],
-                ticket['scope'])
+                        ticket['scope'])
 
             scopes = set(ticket.get('scope', '').split())
             if 'ticket' not in scopes:

--- a/publ/user.py
+++ b/publ/user.py
@@ -11,6 +11,7 @@ import urllib.parse
 
 import arrow
 import authl.disposition
+import authl.handlers.indieauth
 import flask
 from pony import orm
 from werkzeug.utils import cached_property
@@ -228,6 +229,12 @@ def register(verified: authl.disposition):
             record.set(**values)
         else:
             record = model.KnownUser(user=identity, **values)
+
+        if (verified.profile
+            and 'endpoints' in verified.profile
+                and 'ticket_endpoint' in verified.profile['endpoints']):
+            tokens.send_auth_ticket(identity, flask.request.url_root,
+                                    verified.profile['endpoints']['ticket_endpoint'])
 
 
 @orm.db_session(retry=5)

--- a/publ/user.py
+++ b/publ/user.py
@@ -11,7 +11,6 @@ import urllib.parse
 
 import arrow
 import authl.disposition
-import authl.handlers.indieauth
 import flask
 from pony import orm
 from werkzeug.utils import cached_property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ Flask-Caching = "^1.9.0"
 pony = "^0.7.14"
 Pygments = "^2.7.3"
 watchdog = "^1.0.2"
-Werkzeug = "^1.0.1"
 Whoosh = "^2.7.4"
 
 [tool.poetry.dev-dependencies]
@@ -33,6 +32,7 @@ pylint = "^2.5.3"
 pytest = "^5.4.3"
 isort = "^4"
 pytest-mock = "^3.2.0"
+requests-mock = "^1.9.3"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,10 +1,22 @@
 """ test framework stuff """
 
+import logging
 import uuid
 
 import flask
 
 from publ import config
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+class MockIndexer():
+    """ Mock out the indexer for test purposes """
+    # pylint:disable=too-few-public-methods
+    @staticmethod
+    def submit(func, *args, **kwargs):
+        """ fake background submission that just runs immediately """
+        func(*args, **kwargs)
 
 
 class PublMock(flask.Flask):
@@ -14,3 +26,4 @@ class PublMock(flask.Flask):
         super().__init__(__name__, **kwargs)
         self.publ_config = config.Config(cfg or {})
         self.secret_key = uuid.uuid4().bytes
+        self.indexer = MockIndexer()

--- a/tests/templates/userinfo.html
+++ b/tests/templates/userinfo.html
@@ -22,7 +22,11 @@
         </ul></li>
     </ul>
 
-    <p>Auth token test: <code>curl -H 'Authorization: Bearer {{user.token(3600)}}' {{request.url}}</code></p>
+    <p>Auth token tests: <ul>
+        <li>No scope, 1-hour expiration: <code>curl -H 'Authorization: Bearer {{user.token(3600)}}' {{request.url}}</code></li>
+        <li>Read scope, 3-hour expiration: <code>curl -H 'Authorization: Bearer {{user.token(7200,scope='read')}}' {{url_for('tokens',_external=True)}}</code></li>
+
+    </ul></p>
     {% else %}
     No active user
     {% endif %}

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,5 +1,5 @@
 """ Bearer token tests """
-# pylint:disable=missing-docstring
+# pylint:disable=missing-docstring,too-many-statements
 
 import json
 import logging
@@ -106,6 +106,14 @@ def test_ticketauth_flow(requests_mock):
         token = tokens.parse_token(stash['access_token'])
         assert token['me'] == 'https://foo.example/'
 
+        req = client.get(token_endpoint, headers={
+            'Authorization': f'Bearer {stash["access_token"]}'
+        })
+        assert req.status_code == 200
+        assert req.headers['Content-Type'] == 'application/json'
+        verified = json.loads(req.data)
+        assert verified['me'] == 'https://foo.example/'
+
     # Login flow
     stash.clear()
     with app.test_request_context():
@@ -120,3 +128,11 @@ def test_ticketauth_flow(requests_mock):
         assert stash['me'] == 'https://bar.example/'
         token = tokens.parse_token(stash['access_token'])
         assert token['me'] == 'https://bar.example/'
+
+        req = client.get(token_endpoint, headers={
+            'Authorization': f'Bearer {stash["access_token"]}'
+        })
+        assert req.status_code == 200
+        assert req.headers['Content-Type'] == 'application/json'
+        verified = json.loads(req.data)
+        assert verified['me'] == 'https://bar.example/'

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,11 +1,18 @@
 """ Bearer token tests """
 # pylint:disable=missing-docstring
 
+import json
+import logging
+
 import flask
 import pytest
 import werkzeug.exceptions as http_error
 
 from publ import tokens, user
+
+from . import PublMock
+
+LOGGER = logging.getLogger(__name__)
 
 
 def test_token_flow(mocker):
@@ -44,3 +51,72 @@ def test_request():
     with app.test_request_context('/bar'):
         tokens.request(None)
         assert flask.g.needs_auth
+
+
+def test_ticketauth_flow(requests_mock):
+    import authl.disposition
+    app = PublMock()
+    app.add_url_rule('/_tokens', 'tokens', tokens.indieauth_endpoint,
+                     methods=['GET', 'POST'])
+
+    stash = {}
+
+    with app.test_request_context('/'):
+        token_endpoint = flask.url_for('tokens')
+
+    def ticket_endpoint(request, _):
+        import urllib.parse
+        args = urllib.parse.parse_qs(request.text)
+        assert 'subject' in args
+        assert 'ticket' in args
+        assert 'resource' in args
+
+        with app.test_client() as client:
+            req = client.post(token_endpoint, data={
+                'grant_type': 'ticket',
+                'ticket': args['ticket']
+            })
+            token = json.loads(req.data)
+            assert 'access_token' in token
+            assert token['token_type'].lower() == 'bearer'
+            stash.update(token)
+
+    foo_tickets = requests_mock.get('https://foo.example/', text='''
+        <link rel="ticket_endpoint" href="https://foo.example/tickets">
+        ''')
+    bar_tickets = requests_mock.get('https://bar.example/', text='''
+        <link rel="ticket_endpoint" href="https://foo.example/tickets">
+        ''')
+    requests_mock.post('https://foo.example/tickets', text=ticket_endpoint)
+
+    # Request flow
+    with app.test_request_context('/bogus'):
+        request_url = flask.url_for('tokens', me='https://foo.example/')
+        print(request_url)
+    with app.test_client() as client:
+        req = client.get(request_url)
+        LOGGER.info("Got ticket redemption response %d: %s",
+                    req.status_code, req.data)
+        assert req.status_code == 202
+        assert req.data == b'Ticket sent'
+
+        assert foo_tickets.called
+        assert 'access_token' in stash and stash['token_type'].lower() == 'bearer'
+        assert stash['me'] == 'https://foo.example/'
+        token = tokens.parse_token(stash['access_token'])
+        assert token['me'] == 'https://foo.example/'
+
+    # Login flow
+    stash.clear()
+    with app.test_request_context():
+        user.register(authl.disposition.Verified(
+            'https://bar.example/',
+            '/',
+            {'endpoints': {
+                'ticket_endpoint': 'https://foo.example/tickets'
+            }}))
+        assert not bar_tickets.called  # endpoint is already discovered
+        assert 'access_token' in stash and stash['token_type'].lower() == 'bearer'
+        assert stash['me'] == 'https://bar.example/'
+        token = tokens.parse_token(stash['access_token'])
+        assert token['me'] == 'https://bar.example/'

--- a/tests/users.cfg
+++ b/tests/users.cfg
@@ -3,9 +3,9 @@
 test:admin
 test:also_an_admin
 # Just as an example; don't do this on your own site (I mean, unless you really want to)
-fluffy@beesbuzz.biz
+mailto:fluffy@beesbuzz.biz
 
-[fluffy@beesbuzz.biz]
+[mailto:fluffy@beesbuzz.biz]
 http://beesbuzz.biz/
 https://beesbuzz.biz/
 https://queer.party/@fluffy


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Implements Ticket Auth, per #405 

## Detailed description

This change adds support for [TicketAuth](https://indieweb.org/IndieAuth_Ticket_Auth) as well as the necessary parts of an IndieAuth token endpoint. The following flows are supported:

* Automatically sending a ticket if someone signs in from a provider that supports TicketAuth
* Manually requesting a ticket via `https://example.com/_tokens?me=URL_HERE`
* Verifying the ticket via the [token verification flow](https://indieauth.spec.indieweb.org/#access-token-verification) at `https://example.com/_tokens`

This also automatically adds the appropriate `Link` header to all server responses. Additionally, this re-enables the `token_endpoint` Jinja global for use in templates (for example, if someone wants to provide a "send me a ticket" form).

By default, tickets expire after 60 seconds, and resulting tokens expire after 30 days. The token grant also comes with a refresh token (provisional, per https://github.com/indieweb/indieauth/issues/81).

This token endpoint ***does not*** support generic IndieAuth login tokens, as that is reliant on the IndieAuth login provider, which is not part of Publ. Support for that will be hashed out as part of #224.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Full unit test coverage for the TicketAuth flow and token verification.

## Got a site to show off?

<!-- If so, link to it here! -->
