### PR TITLE
Improve first-paragraph extraction

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -470,17 +470,15 @@ class Entry(caching.Memoizable):
             if body or more:
                 html_text = self._get_markup(body or more,
                                              is_markdown,
-                                             args={'count': 1,
-                                                   **kwargs,
+                                             args={**kwargs,
+                                                   'markup': markup,
                                                    "max_scale": 1,
+                                                   "_suppress_images": True,
                                                    "_suppress_footnotes": True,
                                                    "_no_resize_external": True,
                                                    "absolute": True},
                                              counter=markdown.ItemCounter())
-                processor = html_entry.FirstParagraph()
-                processor.feed(html_text)
-
-                html_text = processor.get_data()
+                html_text = html_entry.first_paragraph(html_text)
                 if markup:
                     return flask.Markup(html_text)
 

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -227,8 +227,8 @@ class FirstParagraph(utils.HTMLTransform):
 
 
 def first_paragraph(text):
+    """ Extract the first paragraph of text from an HTML document """
     first_para = FirstParagraph()
     first_para.feed(str(text))
     text = first_para.get_data()
-    text = strip_html(text, allowed_tags=('p',))
     return re.sub(r'<p> *</p>', r'', text)

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -205,7 +205,6 @@ class FirstParagraph(utils.HTMLTransform):
         if tag.lower() == 'p':
             if self._found:
                 self._consume = False
-            self._found = True
 
         if self._consume:
             self.append(utils.make_tag(tag, attrs))
@@ -213,7 +212,7 @@ class FirstParagraph(utils.HTMLTransform):
     def handle_endtag(self, tag):
         if self._consume:
             self.append(f'</{tag}>')
-        if tag.lower() == 'p':
+        if tag.lower() == 'p' and self._found:
             self._consume = False
 
     def handle_startendtag(self, tag, attrs):
@@ -221,6 +220,15 @@ class FirstParagraph(utils.HTMLTransform):
             self.append(utils.make_tag(tag, attrs, True))
 
     def handle_data(self, data):
-        self._found = True
+        if data.strip():
+            self._found = True
         if self._consume:
             self.append(data)
+
+
+def first_paragraph(text):
+    first_para = FirstParagraph()
+    first_para.feed(str(text))
+    text = first_para.get_data()
+    text = strip_html(text, allowed_tags=('p',))
+    return re.sub(r'<p> *</p>', r'', text)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -316,8 +316,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
         """
         # pylint: disable=too-many-locals
 
-        # If we aren't generating markup, there's no reason to do any of this
-        if not self._config.get('markup', True):
+        # If we aren't generating images or markup, there's no reason to do any of this
+        if self._config.get('_suppress_images') or not self._config.get('markup', True):
             return ' '
 
         text = ''

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -182,6 +182,7 @@ def where_entry_tag(query, tags, operation: FilterCombiner):
 
     if operation == FilterCombiner.ALL:
         for tag in tags:
+            # pylint:disable=undefined-loop-variable
             query = query.filter(lambda e: orm.exists(t for t in e.tags
                                                       if t.tag.key == tag))
         return query

--- a/tests/content/cards/image before first paragraph.md
+++ b/tests/content/cards/image before first paragraph.md
@@ -1,0 +1,8 @@
+Title: Image before first paragraph
+Date: 2021-08-13 23:11:48-07:00
+Entry-ID: 3045
+UUID: 66ec122e-709e-5e27-adfb-367dd5e0c4e8
+
+![](/images/rawr.jpg)
+
+This is summary text.

--- a/tests/test_html_entry.py
+++ b/tests/test_html_entry.py
@@ -108,3 +108,7 @@ def test_first_paragraph():
     processor = FirstParagraph()
     processor.feed('<div class="images"><img src="foo"></div>Bare text<p>foo</p>')
     assert processor.get_data() == '<div class="images"><img src="foo"></div>Bare text'
+
+    processor = FirstParagraph()
+    processor.feed('<p><img src="foo"></p><p>Para 1</p>')
+    assert processor.get_data() == '<p><img src="foo"></p><p>Para 1</p>'


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
* First-paragraph extraction now skips things like inline images in their own paragraph, and cleans up better
* Summaries no longer ever generate images on Markdown entries

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->


## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
I *really* want to refactor a bunch of this stuff now

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
