### PR TITLE
Add 'normalize' CLI command

### DIFF
--- a/publ/cli.py
+++ b/publ/cli.py
@@ -1,12 +1,22 @@
 """ CLI utilities for Publ """
+# pylint:disable=too-many-arguments
 
 import itertools
+import logging
+import os.path
+import re
 import time
 
+import arrow
 import click
+import slugify
 from flask.cli import AppGroup, with_appcontext
+from pony import orm
 
+from . import queries
 from .config import config
+
+LOGGER = logging.getLogger(__name__)
 
 publ_cli = AppGroup('publ', short_help="Publ-specific commands")  # pylint:disable=invalid-name
 
@@ -16,7 +26,11 @@ publ_cli = AppGroup('publ', short_help="Publ-specific commands")  # pylint:disab
 @click.option('--fresh', '-f', 'fresh', is_flag=True, help="Start with a fresh database")
 @with_appcontext
 def reindex_command(quietly, fresh):
-    """ Command for reindexing the index """
+    """ Forces a reindex of the content store.
+
+    This is particularly useful to ensure that all content has been indexed
+    before performing another action, such as sending out notifications.
+    """
     from . import index, model
 
     if fresh:
@@ -40,9 +54,114 @@ def reindex_command(quietly, fresh):
 @click.option('--lifetime', '-l', help="The token's lifetime (in seconds)")
 @with_appcontext
 def token_command(identity, scope, lifetime=3600):
-    """ Command to retrieve a bearer token """
+    """ Generates a bearer token for use with external applications. """
     from . import tokens
     print(tokens.get_token(identity, int(lifetime), scope))
+
+
+@publ_cli.command('normalize', short_help="Normalize entry filenames")
+@click.argument('category', nargs=-1)
+@click.option('--recurse', '-r', 'recurse', is_flag=True,
+              help="Include subdirectories")
+@click.option('--all', '-a', 'all_entries', is_flag=True,
+              help="Apply to all entries, not just reachable ones")
+@click.option('--dry-run', '-n', 'dry_run', is_flag=True,
+              help="Show, but don't apply, changes")
+@click.option('--format', '-f', 'format_str',
+              help="Filename format to use",
+              default="{date} {sid} {title}")
+@click.option('--verbose', '-v', 'verbose', is_flag=True,
+              help="Show detailed actions")
+@with_appcontext
+@orm.db_session
+def normalize_command(category, recurse, dry_run, format_str, verbose, all_entries):
+    """ Normalizes the filenames of content files based on a standardized format.
+
+    This will only normalize entries which are already in the content index.
+
+    If no categories are specified, it defaults to the root category. To include
+    the root category in a list of other categories, use an empty string parameter,
+    e.g.:
+
+        flask publ normalize '' blog
+
+    Available tokens for --format/-f:
+
+        {date}    The entry's publish date, in YYYYMMDD format
+
+        {time}    The entry's publish time, in HHMMSS format
+
+        {id}      The entry's ID
+
+        {status}  The entry's publish status
+
+        {sid}     If the entry is reachable, the ID, otherwise the status
+
+        {title}   The entry's title, normalized to filename-safe characters
+
+        {slug}    The entry's slug text
+
+        {type}    The entry's type
+    """
+    # pylint:disable=too-many-locals
+
+    from .model import PublishStatus
+
+    entries = queries.build_query({
+        'category': category or '',
+        'recurse': recurse,
+        '_future': True,
+        '_all': all_entries,
+    })
+
+    fname_slugify = slugify.UniqueSlugify(safe_chars='()[]', separator=' ')
+
+    for entry in entries:
+        path = os.path.dirname(entry.file_path)
+        basename, ext = os.path.splitext(os.path.basename(entry.file_path))
+
+        status = PublishStatus(entry.status)
+
+        eid = entry.id
+        if status == PublishStatus.DRAFT:
+            # Draft entries don't get a stable entry ID
+            eid = status.name
+
+        sid = entry.id if status in (PublishStatus.PUBLISHED,
+                                     PublishStatus.HIDDEN,
+                                     PublishStatus.SCHEDULED) else status.name
+
+        date = arrow.get(entry.local_date)
+
+        dest_basename = format_str.format(
+            date=date.format('YYYYMMDD'),
+            time=date.format('HHmmss'),
+            id=eid,
+            status=status.name,
+            sid=sid,
+            title=entry.title,
+            slug=entry.slug_text,
+            type=entry.entry_type).strip()
+        dest_basename = re.sub(r' +', ' ', dest_basename)
+        dest_basename = fname_slugify(dest_basename)
+
+        if dest_basename != basename:
+            dest_path = os.path.join(path, dest_basename + ext)
+
+            if verbose:
+                print(f'{entry.file_path} -> {dest_path}')
+
+            if not os.path.isfile(entry.file_path):
+                LOGGER.warning('File %s does not exist; is the index up-to-date?', entry.file_path)
+            elif os.path.exists(dest_path):
+                LOGGER.warning('File %s already exists', dest_path)
+            elif not dry_run:
+                try:
+                    os.rename(entry.file_path, dest_path)
+                except OSError:
+                    LOGGER.exception('Error moving %s to %s', entry.file_path, dest_path)
+                entry.file_path = dest_path
+                orm.commit()
 
 
 def setup(app):

--- a/publ/model.py
+++ b/publ/model.py
@@ -16,7 +16,7 @@ DbEntity: orm.core.Entity = db.Entity
 LOGGER = logging.getLogger(__name__)
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 20
+SCHEMA_VERSION = 21
 
 
 class GlobalConfig(DbEntity):
@@ -67,7 +67,7 @@ class Entry(DbEntity):
     status = orm.Required(int)
 
     # UNIX epoch, for ordering and visibility
-    utc_timestamp = orm.Required(int)
+    utc_timestamp = orm.Required(int, size=64)
 
     # arbitrary timezone, for pagination
     local_date = orm.Required(datetime.datetime)

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -274,12 +274,15 @@ def build_query(spec):
     query = model.Entry.select()
 
     # primarily restrict by publication status
-    if spec.get('_deleted', False):
+    if spec.get('_all', False):
+        pass
+    elif spec.get('_deleted', False):
         query = where_entry_deleted(query)
-    elif spec.get('future', False):
-        query = where_entry_visible_future(query)
     else:
-        query = where_entry_visible(query)
+        if spec.get('future', False):
+            query = where_entry_visible_future(query)
+        else:
+            query = where_entry_visible(query)
 
     # restrict by category
     if spec.get('category') is not None:

--- a/tests/content/normalize/20211007 1223 Normalize (hidden).md
+++ b/tests/content/normalize/20211007 1223 Normalize (hidden).md
@@ -1,0 +1,6 @@
+Title: Normalize (hidden)
+Publish-Status: HIDDEN
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 1223
+UUID: 387aeb8d-9fdd-55eb-9f64-69260712e4bd
+

--- a/tests/content/normalize/20211007 2044 Normalize.md
+++ b/tests/content/normalize/20211007 2044 Normalize.md
@@ -1,0 +1,5 @@
+Title: Normalize
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 2044
+UUID: f0b92f36-ac76-594d-8dc1-8e65e86200f3
+

--- a/tests/content/normalize/20211007 2163 Normalize.md
+++ b/tests/content/normalize/20211007 2163 Normalize.md
@@ -1,0 +1,5 @@
+Title: Normalize
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 2163
+UUID: 367b3956-9c99-53c7-a044-0a432e78241a
+

--- a/tests/content/normalize/20211007 2695 Normalize.md
+++ b/tests/content/normalize/20211007 2695 Normalize.md
@@ -1,0 +1,5 @@
+Title: Normalize
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 2695
+UUID: 94c4ffba-5738-56c6-9f9d-3908c53504b9
+

--- a/tests/content/normalize/20211007 3288 Normalize.md
+++ b/tests/content/normalize/20211007 3288 Normalize.md
@@ -1,0 +1,5 @@
+Title: Normalize
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 3288
+UUID: 02c65021-fbc4-55dc-b34a-475e1646abcd
+

--- a/tests/content/normalize/20211007 70 Normalize.md
+++ b/tests/content/normalize/20211007 70 Normalize.md
@@ -1,0 +1,5 @@
+Title: Normalize
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 70
+UUID: e2ad5ee4-35fc-5715-99d7-498ac88bdbc5
+

--- a/tests/content/normalize/20211007 891 Normalize.md
+++ b/tests/content/normalize/20211007 891 Normalize.md
@@ -1,0 +1,5 @@
+Title: Normalize
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 891
+UUID: 9f9077d0-4c5e-5c1f-855a-3364a35eed7d
+

--- a/tests/content/normalize/20211007 DRAFT Normalize (draft).md
+++ b/tests/content/normalize/20211007 DRAFT Normalize (draft).md
@@ -1,0 +1,5 @@
+Title: Normalize (draft)
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 1470
+UUID: 5f77bc5f-1298-5bc6-8fa1-a2bf07065241
+Status: DRAFT

--- a/tests/content/normalize/20211007 GONE Normalize (gone).md
+++ b/tests/content/normalize/20211007 GONE Normalize (gone).md
@@ -1,0 +1,5 @@
+Title: Normalize (gone)
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 1678
+UUID: 404366be-5ac3-5f21-b2a8-e4147fbea040
+Status: GONE

--- a/tests/content/normalize/20211007 ILLEGAL Normalize (dmca).md
+++ b/tests/content/normalize/20211007 ILLEGAL Normalize (dmca).md
@@ -1,0 +1,5 @@
+Title: Normalize (dmca)
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 1638
+UUID: 41258817-aa80-5b73-ade7-e5d67bf1d8f2
+Status: DMCA

--- a/tests/content/normalize/20211007 TEAPOT Normalize (teapot).md
+++ b/tests/content/normalize/20211007 TEAPOT Normalize (teapot).md
@@ -1,0 +1,5 @@
+Title: Normalize (teapot)
+Date: 2021-10-07 17:40:20-07:00
+Entry-ID: 1887
+UUID: f5036f9e-4489-579a-898b-c9ce6b8f2735
+Status: TEAPOT

--- a/tests/content/normalize/20390101 2739 Normalize (future).md
+++ b/tests/content/normalize/20390101 2739 Normalize (future).md
@@ -1,0 +1,5 @@
+Title: Normalize (future)
+Date: 2039-01-01
+Entry-ID: 2739
+UUID: 7f8e1e0c-b8b3-5c80-a58e-fb445f13c6e6
+


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Implements a `flask publ normalize` command to allow bulk file renaming. Fixes #454 
<!-- Summary of the PR; please link to any issue(s) that this solves -->

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

This adds a `normalize` command to the `publ` CLI, which allows one to renormalize entry filenames. It allows specifying one or more categories to restrict the selection to (with recursion as an option). By default it will only apply to reachable entries and in the root category.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Manually tested with the `-n` flag as well as actually changing the filenames of things in `content/normalize`

## Got a site to show off?

<!-- If so, link to it here! -->
