### PR TITLE
Feature/fix misparsed tokens

### DIFF
--- a/publ/cli.py
+++ b/publ/cli.py
@@ -51,9 +51,9 @@ def reindex_command(quietly, fresh):
 @publ_cli.command('token', short_help="Generate a bearer token")
 @click.argument('identity')
 @click.option('--scope', '-s', help="The token's permission scope")
-@click.option('--lifetime', '-l', help="The token's lifetime (in seconds)")
+@click.option('--lifetime', '-l', help="The token's lifetime (in seconds)", default=3600)
 @with_appcontext
-def token_command(identity, scope, lifetime=3600):
+def token_command(identity, scope, lifetime):
     """ Generates a bearer token for use with external applications. """
     from . import tokens
     print(tokens.get_token(identity, int(lifetime), scope))

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -35,8 +35,8 @@ def parse_token(token: str) -> typing.Dict[str, str]:
         ident, expires = signer().loads(token)
     except itsdangerous.BadData as error:
         LOGGER.error("Got token parse error: %s", error)
-        flask.g.token_error = error.message
-        raise http_error.Unauthorized(error.message)
+        flask.g.token_error = 'Invalid token'
+        raise http_error.Unauthorized('Invalid token') from error
 
     if expires < time.time():
         LOGGER.info("Got expired token for %s", ident['me'])

--- a/test_app.py
+++ b/test_app.py
@@ -50,7 +50,7 @@ config = {
     'layout': {
         'max_width': 768,
     },
-    'search_index': '_index'
+    'search_index': '_index',
 }
 
 app = publ.Publ(__name__, config)


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes exception recursion error when handling a bad `Authorization` header; fixes #466 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

When a token failed due to malformed/expired token or malformed header, this would result in an error page. But the error handler was also trying to get the active user, which in turn was trying to parse the bad header. This led to an overall failure.

The fix was to make use of the already-existing `token_error` field on the context which informs us that the token already failed to parse, and to make `user.get_active()` return `None`.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Manually tested with invalid, expired, malformed, and valid tokens via `curl -H`.

## Got a site to show off?

<!-- If so, link to it here! -->
