### PR TITLE
Implement the provisional TicketAuth request flow

### DIFF
--- a/publ/config.py
+++ b/publ/config.py
@@ -55,6 +55,7 @@ class _Defaults:
     auth_log_prune_age = 86400 * 30  # one month
     ticket_lifetime = 60
     token_lifetime = 86400 * 30
+    refresh_token_lifetime = 86400 * 90
 
     # Full-text search directory
     search_index = None

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -106,7 +106,7 @@ def redeem_grant(grant_type: str, auth_token: str):
     return json.dumps(response), {'Content-Type': 'application/json'}
 
 
-def ticket_request(me_url: str):
+def ticket_request(me_url: str, scope: str):
     """ Initiate a ticket request """
     import authl.handlers.indieauth
 
@@ -118,7 +118,7 @@ def ticket_request(me_url: str):
     if not endpoint:
         raise http_error.BadRequest("Could not get ticket endpoint")
     LOGGER.info("endpoint: %s", endpoint)
-    send_auth_ticket(me_url, flask.request.url_root, endpoint)
+    send_auth_ticket(me_url, flask.request.url_root, endpoint, scope)
     return "Ticket sent", 202
 
 
@@ -157,7 +157,8 @@ def indieauth_endpoint():
     if 'action' in flask.request.form:
         # provisional ticket request flow, per https://github.com/indieweb/indieauth/issues/87
         if flask.request.form['action'] == 'ticket' and 'subject' in flask.request.form:
-            return ticket_request(flask.request.form['subject'])
+            return ticket_request(flask.request.form['subject'],
+                                  flask.request.form.get('scope', ''))
 
         raise http_error.BadRequest()
 
@@ -168,6 +169,7 @@ def indieauth_endpoint():
 
     if 'me' in flask.request.args:
         # ad-hoc ticket request
-        return ticket_request(flask.request.args['me'])
+        return ticket_request(flask.request.args['me'],
+                              flask.request.args.get('scope', ''))
 
     raise http_error.BadRequest()

--- a/publ/tokens.py
+++ b/publ/tokens.py
@@ -15,25 +15,25 @@ from .config import config
 LOGGER = logging.getLogger(__name__)
 
 
-def signer():
+def signer(context: str):
     """ Gets the signer/validator for the tokens """
     from .flask_wrapper import current_app
-    return itsdangerous.URLSafeSerializer(current_app.secret_key)
+    return itsdangerous.URLSafeSerializer(str(current_app.secret_key) + context)
 
 
-def get_token(id_url: str, lifetime: int, scope: str = None) -> str:
+def get_token(id_url: str, lifetime: int, scope: str = None, context: str = '') -> str:
     """ Gets a signed token for the given identity"""
     token = {'me': id_url}
     if scope:
         token['scope'] = scope
 
-    return signer().dumps((token, int(time.time() + lifetime)))
+    return signer(context).dumps((token, int(time.time() + lifetime)))
 
 
-def parse_token(token: str) -> typing.Dict[str, str]:
+def parse_token(token: str, context: str = '') -> typing.Dict[str, str]:
     """ Parse a bearer token to get the stored data """
     try:
-        ident, expires = signer().loads(token)
+        ident, expires = signer(context).loads(token)
     except itsdangerous.BadData as error:
         LOGGER.error("Got token parse error: %s", error)
         flask.g.token_error = 'Invalid token'  # pylint:disable=assigning-non-slot
@@ -67,9 +67,7 @@ def send_auth_ticket(subject: str,
     from .flask_wrapper import current_app
 
     def _submit():
-        scopes = set(scope.split() if scope else [])
-        scopes.add('ticket')
-        ticket = get_token(subject, config.ticket_lifetime, ' '.join(scopes))
+        ticket = get_token(subject, config.ticket_lifetime, scope, context='ticket')
 
         req = requests.post(endpoint, data={
             'ticket': ticket,
@@ -81,6 +79,31 @@ def send_auth_ticket(subject: str,
 
     # Use the indexer's threadpool to issue the ticket in the background
     current_app.indexer.submit(_submit)
+
+
+def redeem_grant(grant_type: str, auth_token: str):
+    """ Redeem a grant from a provided redemption ticket """
+    grant = parse_token(auth_token, grant_type)
+    LOGGER.info("Redeeming %s for %s; scopes=%s", grant_type, grant['me'],
+                grant.get('scope'))
+
+    scope = grant.get('scope', '')
+
+    token = get_token(grant['me'], config.token_lifetime, scope)
+    response = {
+        'access_token': token,
+        'token_type': 'Bearer',
+        'me': grant['me'],
+        'expires_in': config.token_lifetime,
+        'refresh_token': get_token(grant['me'],
+                                   config.refresh_token_lifetime,
+                                   scope,
+                                   context='refresh_token')
+    }
+    if scope:
+        response['scope'] = scope
+
+    return json.dumps(response), {'Content-Type': 'application/json'}
 
 
 def ticket_request(me_url: str):
@@ -99,6 +122,19 @@ def ticket_request(me_url: str):
     return "Ticket sent", 202
 
 
+def parse_authorization_header(header):
+    """ Parse an Authorization: header from an HTTP request into token """
+    parts = header.split()
+    if len(parts) < 2:
+        raise http_error.BadRequest("Malformed authorization header")
+
+    if parts[0].lower() == 'bearer':
+        token = parse_token(parts[1])
+        return token
+
+    raise http_error.BadRequest(f"Unknown authorization type '{parts[0]}'")
+
+
 def indieauth_endpoint():
     """ IndieAuth token endpoint """
 
@@ -108,32 +144,13 @@ def indieauth_endpoint():
             # TicketAuth
             if 'ticket' not in flask.request.form:
                 raise http_error.BadRequest("Missing ticket")
+            return redeem_grant('ticket', flask.request.form['ticket'])
 
-            ticket = parse_token(flask.request.form['ticket'])
-            LOGGER.info("Redeeming ticket for %s; scopes=%s", ticket['me'],
-                        ticket['scope'])
-
-            scopes = set(ticket.get('scope', '').split())
-            if 'ticket' not in scopes:
-                raise http_error.BadRequest("Missing 'ticket' scope")
-
-            scopes.remove('ticket')
-            scope = ' '.join(scopes)
-
-            token = get_token(ticket['me'], config.token_lifetime, scope)
-            response = {
-                'access_token': token,
-                'token_type': 'Bearer',
-                'me': ticket['me'],
-                'expires_in': config.token_lifetime,
-                'refresh_token': get_token(ticket['me'],
-                                           config.token_lifetime,
-                                           ticket['scope'])
-            }
-            if scope:
-                response['scope'] = scope
-
-            return json.dumps(response), {'Content-Type': 'application/json'}
+        if flask.request.form['grant_type'] == 'refresh_token':
+            # Refresh token redemption
+            if 'refresh_token' not in flask.request.form:
+                raise http_error.BadRequest("Missing refresh_token")
+            return redeem_grant('refresh_token', flask.request.form['refresh_token'])
 
         raise http_error.BadRequest("Unknown grant type")
 
@@ -146,11 +163,8 @@ def indieauth_endpoint():
 
     if 'Authorization' in flask.request.headers:
         # ticket verification
-        parts = flask.request.headers['Authorization'].split()
-        if parts[0].lower() == 'bearer':
-            token = parse_token(parts[1])
-            return json.dumps(token), {'Content-Type': 'application/json'}
-        raise http_error.Unauthorized("Invalid authorization header")
+        token = parse_authorization_header(flask.request.headers['Authorization'])
+        return json.dumps(token), {'Content-Type': 'application/json'}
 
     if 'me' in flask.request.args:
         # ad-hoc ticket request

--- a/publ/user.py
+++ b/publ/user.py
@@ -179,13 +179,12 @@ def get_active() -> typing.Optional[User]:
         return None
 
     if 'Authorization' in flask.request.headers:
-        parts = flask.request.headers['Authorization'].split()
-        if parts[0].lower() == 'bearer':
-            token = tokens.parse_token(parts[1])
+        token = tokens.parse_authorization_header(flask.request.headers['Authorization'])
+        try:
             return User(token['me'], 'token', token.get('scope'))
-
-        flask.g['token_error'] = 'Malformed access token'
-        raise http_error.BadRequest('Malformed access token')
+        except http_error.HTTPException as error:
+            flask.g['token_error'] = error.description
+            raise
 
     if flask.session.get('me'):
         return User(flask.session['me'], 'session')

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -61,15 +61,13 @@ def test_ticketauth_flow(requests_mock):
 
     stash = {}
 
-    with app.test_request_context('/'):
-        token_endpoint = flask.url_for('tokens')
-
     def ticket_endpoint(request, _):
         import urllib.parse
         args = urllib.parse.parse_qs(request.text)
         assert 'subject' in args
         assert 'ticket' in args
         assert 'resource' in args
+        stash['ticket'] = args['ticket']
 
         with app.test_client() as client:
             req = client.post(token_endpoint, data={
@@ -79,7 +77,10 @@ def test_ticketauth_flow(requests_mock):
             token = json.loads(req.data)
             assert 'access_token' in token
             assert token['token_type'].lower() == 'bearer'
-            stash.update(token)
+            stash['response'] = token
+
+    with app.test_request_context('/'):
+        token_endpoint = flask.url_for('tokens')
 
     foo_tickets = requests_mock.get('https://foo.example/', text='''
         <link rel="ticket_endpoint" href="https://foo.example/tickets">
@@ -100,13 +101,13 @@ def test_ticketauth_flow(requests_mock):
         assert req.data == b'Ticket sent'
 
         assert foo_tickets.called
-        assert 'access_token' in stash and stash['token_type'].lower() == 'bearer'
-        assert stash['me'] == 'https://foo.example/'
-        token = tokens.parse_token(stash['access_token'])
+        assert stash['response']['token_type'].lower() == 'bearer'
+        assert stash['response']['me'] == 'https://foo.example/'
+        token = tokens.parse_token(stash['response']['access_token'])
         assert token['me'] == 'https://foo.example/'
 
         req = client.get(token_endpoint, headers={
-            'Authorization': f'Bearer {stash["access_token"]}'
+            'Authorization': f'Bearer {stash["response"]["access_token"]}'
         })
         assert req.status_code == 200
         assert req.headers['Content-Type'] == 'application/json'
@@ -125,13 +126,13 @@ def test_ticketauth_flow(requests_mock):
         assert req.data == b'Ticket sent'
 
         assert foo_tickets.called
-        assert 'access_token' in stash and stash['token_type'].lower() == 'bearer'
-        assert stash['me'] == 'https://foo.example/'
-        token = tokens.parse_token(stash['access_token'])
+        assert stash['response']['token_type'].lower() == 'bearer'
+        assert stash['response']['me'] == 'https://foo.example/'
+        token = tokens.parse_token(stash['response']['access_token'])
         assert token['me'] == 'https://foo.example/'
 
         req = client.get(token_endpoint, headers={
-            'Authorization': f'Bearer {stash["access_token"]}'
+            'Authorization': f'Bearer {stash["response"]["access_token"]}'
         })
         assert req.status_code == 200
         assert req.headers['Content-Type'] == 'application/json'
@@ -148,15 +149,55 @@ def test_ticketauth_flow(requests_mock):
                 'ticket_endpoint': 'https://foo.example/tickets'
             }}))
         assert not bar_tickets.called  # endpoint is already discovered
-        assert 'access_token' in stash and stash['token_type'].lower() == 'bearer'
-        assert stash['me'] == 'https://bar.example/'
-        token = tokens.parse_token(stash['access_token'])
+        assert stash['response']['token_type'].lower() == 'bearer'
+        assert stash['response']['me'] == 'https://bar.example/'
+        token = tokens.parse_token(stash['response']['access_token'])
         assert token['me'] == 'https://bar.example/'
 
         req = client.get(token_endpoint, headers={
-            'Authorization': f'Bearer {stash["access_token"]}'
+            'Authorization': f'Bearer {stash["response"]["access_token"]}'
         })
         assert req.status_code == 200
         assert req.headers['Content-Type'] == 'application/json'
         verified = json.loads(req.data)
         assert verified['me'] == 'https://bar.example/'
+
+    # Attempt to redeem a token as if it were a ticket
+    with app.test_request_context():
+        req = client.post(token_endpoint, data={
+            'grant_type': 'ticket',
+            'ticket': stash['response']['access_token']})
+        assert req.status_code == 401
+
+    # Redeem the refresh_token
+    with app.test_client() as client:
+        req = client.post(token_endpoint, data={
+            'grant_type': 'refresh_token',
+            'refresh_token': stash['response']['refresh_token']
+        })
+        assert req.status_code == 200
+        assert req.headers['Content-Type'] == 'application/json'
+        refreshed = json.loads(req.data)
+        assert refreshed['me'] == 'https://bar.example/'
+
+    # Verify that redemption of a plain token fails
+    with app.test_client() as client:
+        req = client.post(token_endpoint, data={
+            'grant_type': 'refresh_token',
+            'refresh_token': stash['response']['access_token']
+        })
+        assert req.status_code == 401
+
+    # Verify that a ticket can't be used as a bearer token
+    with app.test_client() as client:
+        req = client.get(token_endpoint, headers={
+            'Authorization': f'Bearer {stash["ticket"]}'
+        })
+        assert req.status_code == 401
+
+    # Verify that a refresh_token can't be used as a bearer token
+    with app.test_client() as client:
+        req = client.get(token_endpoint, headers={
+            'Authorization': f'Bearer {stash["response"]["refresh_token"]}'
+        })
+        assert req.status_code == 401


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Adds the `action=ticket` verb to the token endpoint, as discussed at https://github.com/indieweb/indieauth/issues/87

## Test plan

Awaiting confirmation of real-world functionality from @omz13.