### PR TITLE
Allow disabling the watchdog for production use

### DIFF
--- a/publ/config.py
+++ b/publ/config.py
@@ -19,6 +19,7 @@ class _Defaults:
     }
     index_rescan_interval = 7200
     index_wait_time = 1
+    index_enable_watchdog = True
 
     # Site content locations
     content_folder = 'content'

--- a/publ/flask_wrapper.py
+++ b/publ/flask_wrapper.py
@@ -313,7 +313,8 @@ class Publ(flask.Flask):
             ctx = click.get_current_context(silent=True)
             if not ctx or ctx.info_name == 'run':
                 index.scan_index(self.publ_config.content_folder)
-                index.background_scan(self.publ_config.content_folder)
+                if self.publ_config.index_enable_watchdog:
+                    index.background_scan(self.publ_config.content_folder)
 
 
 current_app = typing.cast(Publ, flask.current_app)  # pylint:disable=invalid-name

--- a/test_app.py
+++ b/test_app.py
@@ -51,6 +51,7 @@ config = {
         'max_width': 768,
     },
     'search_index': '_index',
+    'index_enable_watchdog': False,
 }
 
 app = publ.Publ(__name__, config)


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Allow disabling the index watchdog; fixes #475 

## Detailed description

In production setups, dynamically creating content based on external events (form submissions, RSS feeds, etc.) is perilous because the index watchdog can end up stomping over the automated changes, which can lead to duplicate entries or other weird behavior. This adds a configuration option, `index_enable_watchdog`, which defaults to `True` but can be disabled, so as to allow a production site to choose when content gets reindexed.

## Test plan

Manually smoke-tested.
