### PR TITLE
Properly strip tables when extracting an entry summary

### DIFF
--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -204,6 +204,9 @@ class FirstParagraph(utils.HTMLTransform):
         self._tag_stack = []
 
     def handle_starttag(self, tag, attrs):
+        if tag.lower() == 'table':
+            self._consume = False
+
         if tag.lower() == 'p':
             if self._found:
                 self._consume = False
@@ -219,6 +222,10 @@ class FirstParagraph(utils.HTMLTransform):
 
         if self._consume:
             self.append(f'</{tag}>')
+
+        if tag.lower() == 'table' and not self._found:
+            self._consume = True
+
         if (not self._tag_stack or tag.lower() == 'p') and self._found:
             self._consume = False
 
@@ -227,9 +234,8 @@ class FirstParagraph(utils.HTMLTransform):
             self.append(utils.make_tag(tag, attrs, True))
 
     def handle_data(self, data):
-        if data.strip():
+        if self._consume and data.strip():
             self._found = True
-        if self._consume:
             self.append(data)
 
 

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -31,7 +31,7 @@ TOC_ALLOWED_TAGS = ('sup', 'sub',
                     'del', 'add', 'mark')
 
 # Remove these tags from plaintext-style conversions
-PLAINTEXT_REMOVE_ELEMENTS = ('del', 's')
+PLAINTEXT_REMOVE_ELEMENTS = ('del', 's', 'table')
 
 
 class ItemCounter(misaka.BaseRenderer):

--- a/tests/content/cards/table in summary paragraph.md
+++ b/tests/content/cards/table in summary paragraph.md
@@ -1,0 +1,20 @@
+Title: Table in summary paragraph
+Date: 2022-03-20 12:34:00-07:00
+Entry-ID: 1711
+UUID: e5fe5b31-039a-5838-b481-bde0001e28e1
+
+| Name | Value |
+|------|-------|
+| foo  | 1 |
+| bar  | 2 |
+| baz  | 3 |
+
+This entry starts with a table. This paragraph should be the summary.
+
+| Name | Value |
+|------|-------|
+| foo  | 1 |
+| bar  | 2 |
+| baz  | 3 |
+
+This second paragraph shouldn't appear in the summary.


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Remove tables from entry summaries; fixes #478

## Detailed description

Table content no longer appears as part of the "first paragraph" in HTML summaries, and the `<table>` element gets removed from the plaintext summary.

## Test plan

`tests/cards/table in summary paragraph.md`

## Got a site to show off?

<!-- If so, link to it here! -->
