### PR TITLE
Register users who log in via TicketAuth grant

### DIFF
--- a/publ/default_template/_admin.html
+++ b/publ/default_template/_admin.html
@@ -223,7 +223,12 @@ td.profile:hover {
         {% if user.last_login %}
         <li>Logged in: {{date(user.last_login)}}</li>
         {% endif %}
+        {% if user.last_seen %}
         <li>Last seen: {{date(user.last_seen)}}</li>
+        {% endif %}
+        {% if user.last_token %}
+        <li>Last token grant: {{date(user.last_token)}}</li>
+        {% endif %}
         {% if profile.email %}<li>Email: <a href="mailto:{{profile.email}}">{{profile.email}}</a></li>{% endif %}
         {% if profile.homepage and profile.homepage != user.identity %}
         <li>Homepage: <a href="{{profile.homepage}}">{{profile.homepage}}</a></li>

--- a/publ/model.py
+++ b/publ/model.py
@@ -16,7 +16,7 @@ DbEntity: orm.core.Entity = db.Entity
 LOGGER = logging.getLogger(__name__)
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 21
+SCHEMA_VERSION = 22
 
 
 class GlobalConfig(DbEntity):
@@ -199,6 +199,7 @@ class KnownUser(DbEntity):
     user = orm.PrimaryKey(str)
     last_login = orm.Optional(datetime.datetime)
     last_seen = orm.Required(datetime.datetime, index=True)
+    last_token = orm.Optional(datetime.datetime)
     profile = orm.Optional(orm.Json)
 
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -101,7 +101,7 @@ def test_ticketauth_flow(requests_mock):
         assert req.status_code == 202
         assert req.data == b'Ticket sent'
 
-        assert foo_tickets.called
+        assert foo_tickets.call_count == 1
         assert stash['response']['token_type'].lower() == 'bearer'
         assert stash['response']['me'] == 'https://foo.example/'
         token = tokens.parse_token(stash['response']['access_token'])

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -84,6 +84,7 @@ def test_ticketauth_flow(requests_mock):
 
     foo_tickets = requests_mock.get('https://foo.example/', text='''
         <link rel="ticket_endpoint" href="https://foo.example/tickets">
+        <p class="h-card"><span class="p-name">boop</span></p>
         ''')
     bar_tickets = requests_mock.get('https://bar.example/', text='''
         <link rel="ticket_endpoint" href="https://foo.example/tickets">
@@ -114,6 +115,10 @@ def test_ticketauth_flow(requests_mock):
         verified = json.loads(req.data)
         assert verified['me'] == 'https://foo.example/'
 
+    token_user = user.User(verified['me'])
+    assert token_user.profile['name'] == 'boop'
+    foo_tickets.reset()
+
     # Provisional request flow
     with app.test_request_context('/bogus'):
         request_url = flask.url_for('tokens')
@@ -125,7 +130,7 @@ def test_ticketauth_flow(requests_mock):
         assert req.status_code == 202
         assert req.data == b'Ticket sent'
 
-        assert foo_tickets.called
+        assert not foo_tickets.called  # should be cached from previous test
         assert stash['response']['token_type'].lower() == 'bearer'
         assert stash['response']['me'] == 'https://foo.example/'
         token = tokens.parse_token(stash['response']['access_token'])
@@ -148,7 +153,7 @@ def test_ticketauth_flow(requests_mock):
             {'endpoints': {
                 'ticket_endpoint': 'https://foo.example/tickets'
             }}))
-        assert not bar_tickets.called  # endpoint is already discovered
+        assert bar_tickets.called  # page still needs to be retrieved to get the profile
         assert stash['response']['token_type'].lower() == 'bearer'
         assert stash['response']['me'] == 'https://bar.example/'
         token = tokens.parse_token(stash['response']['access_token'])


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

When a user obtains a token via TicketAuth, add them to the known user table; fixes #483 

When a user signs in via the TicketAuth request flow, also retrieve their IndieAuth profile; fixes #484 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

This adds a `last_token` column to the user table, and updates that when a user obtains a token grant. it also takes advantage of the fact the IndieAuth profile is being fetched as part of parsing out the endpoint, and uses that to update the user's profile.

## Developer/user impact

There is a schema change, so a site reindex will take place.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
