### PR TITLE
Canonicize user identity URLs

### DIFF
--- a/publ/user.py
+++ b/publ/user.py
@@ -223,7 +223,7 @@ def register(verified: authl.disposition):
     """ Registers a user from the on_verified Authl hook """
     if isinstance(verified, authl.disposition.Verified):
         LOGGER.info("Got login from user %s with profile %s", verified.identity, verified.profile)
-        identity = verified.identity
+        identity = utils.canonicize_url(verified.identity)
         now = arrow.utcnow().datetime
         values = {
             'last_login': now,

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -629,3 +629,14 @@ def parse_arglist(args: str, pos_limit: int = None) -> typing.Tuple[list, ArgDic
 
     LOGGER.debug("pos_args=%s kw_args=%s", pos_args, kwargs)
     return pos_args, kwargs
+
+
+def canonicize_url(url: str) -> str:
+    """ Canonicize a URL to make them string-comparable """
+    assert url is not None
+
+    parsed = urllib.parse.urlparse(url)._asdict()
+    parsed['netloc'] = parsed['netloc'].casefold()
+    if not parsed.get('path'):
+        parsed['path'] = '/'
+    return urllib.parse.urlunparse(urllib.parse.ParseResult(**parsed))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -383,3 +383,15 @@ def test_auth_link_https():
         assert utils.auth_link("login")("/foo") == "https://example.com/_login/foo"
         assert utils.auth_link("login")("/bar",
                                         absolute=True) == "https://example.com/_login/bar"
+
+
+def test_canonicize_url():
+    """ Test the canonicization of URLs for string-equivalence """
+    for lhs, rhs in (('https://foo.bar', 'https://foo.bar/'),
+                     ('https://Foo.Bar', 'https://foo.BAR')):
+        assert utils.canonicize_url(lhs) == utils.canonicize_url(rhs)
+
+    for lhs, rhs in (('http://foo.bar', 'https://foo.bar/'),
+                     ('https://foo.bar/a', 'https://foo.bar/b'),
+                     ('https://foo.bar/a', 'https://foo.bar/a/')):
+        assert utils.canonicize_url(lhs) != utils.canonicize_url(rhs)


### PR DESCRIPTION
…uth requests

<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Canonicizes identity URLs to make the netloc case-insensitive and path non-empty.

Supports `rel="canonical"` on TicketAuth grant requests. Fixes #486 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
The users `http://example.com`, `http://Example.com`, and `http://example.com/` should all be equivalent.

Also, since TicketAuth has no mechanism for the endpoint to provide its own canonical identity, the only way for TicketAuth to prove ownership of a canonical URL is for the profile to provide `rel="canonical"` and for the ticket granter to forward its request to that canonical URL. So this change will forward a TicketAuth grant request if `rel="canonical"` is provided, with no trust given to the forwarding page (to avoid the situation where for example `https://alice.example` provides a TicketAuth endpoint and also a `rel="canonical"` of `https://bob.example`).

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added appropriate unit tests.

## Got a site to show off?

<!-- If so, link to it here! -->
