### PR TITLE
Enforce security on Entry.get, Entry.get_all

### DIFF
--- a/publ/user.py
+++ b/publ/user.py
@@ -126,7 +126,7 @@ class User(caching.Memoizable):
     @cached_property
     def is_admin(self) -> bool:
         """ Returns whether this user has administrator permissions """
-        return bool(config.admin_group and config.admin_group in self.groups)
+        return bool(config.admin_group and config.admin_group in self.auth_groups)
 
     @cached_property
     def auth_type(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ import uuid
 
 import flask
 
-from publ import config
+from publ import caching, config
 
 logging.basicConfig(level=logging.DEBUG)
 logging.getLogger().setLevel(logging.DEBUG)
@@ -28,3 +28,16 @@ class PublMock(flask.Flask):
         self.publ_config = config.Config(cfg or {})
         self.secret_key = uuid.uuid4().bytes
         self.indexer = MockIndexer()
+
+        caching.init_app(self, config={'CACHE_TYPE': 'NullCache'})
+
+        for route in [
+            '/<int:entry_id>',
+            '/<path:category>/<int:entry_id>-<slug_text>'
+        ]:
+            self.add_url_rule(route, 'entry', self.stub_entry)
+
+    @staticmethod
+    def stub_entry(**kwargs):
+        """ stub """
+        return kwargs

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,0 +1,62 @@
+""" Unit tests for entry objects """
+
+import flask
+from pony import orm
+
+from publ import entry, model
+
+from . import PublMock
+
+
+def test_get_permissions():
+    """ Test the permissions on entry attributes """
+    app = PublMock()
+
+    # Test logged-out
+    with app.test_request_context('/'), orm.db_session():
+        record = model.Entry.get(id=107)
+        authed = entry.Entry.load(record)
+
+        assert not authed.authorized
+        assert authed.permalink() == '/107'
+
+        assert not authed.title()
+        assert authed.title(always_show=True) == 'Friends + specific user'
+
+        assert not authed.get('title')
+        assert not authed.get_all('title')
+
+        assert authed.get('title', always_show=True) == 'Friends + specific user'
+        assert authed.get_all('title', always_show=True) == ['Friends + specific user']
+
+        assert authed.uuid == 'e63eff37-042b-58bf-8330-ace5a5db6ab7'
+        assert authed.get('uuid') == 'e63eff37-042b-58bf-8330-ace5a5db6ab7'
+        assert authed.get_all('uuid') == ['e63eff37-042b-58bf-8330-ace5a5db6ab7']
+
+    # test logged-in as user
+    with app.test_request_context('/'), orm.db_session():
+        flask.session['me'] = 'test:specific'
+
+        record = model.Entry.get(id=107)
+        authed = entry.Entry.load(record)
+
+        assert authed.authorized
+        assert authed.permalink() == '/auth/107-Friends-specific-user'
+
+        assert authed.title() == 'Friends + specific user'
+        assert authed.get('title') == 'Friends + specific user'
+        assert authed.get_all('title') == ['Friends + specific user']
+
+    # test logged-in as admin
+    with app.test_request_context('/'), orm.db_session():
+        flask.session['me'] = 'admin'
+
+        record = model.Entry.get(id=107)
+        authed = entry.Entry.load(record)
+
+        assert authed.authorized
+        assert authed.permalink() == '/auth/107-Friends-specific-user'
+
+        assert authed.title() == 'Friends + specific user'
+        assert authed.get('title') == 'Friends + specific user'
+        assert authed.get_all('title') == ['Friends + specific user']


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Enforce attribute security on `.get` and `.get_all`

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

Now when doing `.get` on a protected attribute, it will return blank unless the new argument `always_allow=True`.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Finally added some heckin' unit tests for `publ.entry`

## Got a site to show off?

<!-- If so, link to it here! -->
