### PR TITLE
Defer the rendering of images to the first actual request

### DIFF
--- a/publ/flask_wrapper.py
+++ b/publ/flask_wrapper.py
@@ -113,7 +113,7 @@ class Publ(flask.Flask):
         self.add_url_rule('/<path:path>.PUBL_PATHALIAS',
                           'path_alias', rendering.render_path_alias)
 
-        self.add_url_rule('/_async/<path:filename>',
+        self.add_url_rule('/_async/<path:render_spec>',
                           'async', image.get_async)
 
         self.add_url_rule('/_', 'chit', rendering.render_transparent_chit)

--- a/tests/content/images/image renditions.md
+++ b/tests/content/images/image renditions.md
@@ -46,9 +46,9 @@ Image using static path
 
 Force absolute URLs
 
-![{640,320,absolute=True}](//placekitten.com/800/600 | @images/IMG_0377.jpg)
+![{640,320,absolute=True}](//placekitten.com/800/600 | @images/IMG_0377.jpg | critter.webp{999,format='png'})
 
-`![{640,320,absolute=True}](//placekitten.com/800/600 | @images/IMG_0377.jpg)`
+`![{640,320,absolute=True}](//placekitten.com/800/600 | @images/IMG_0377.jpg | critter.webp{999,format='png'})`
 
 
 ## Local images


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Only render an image when it's first requested  by a browser. Fixes #455 

## Detailed description

Instead of immediately scheduling images for rendering at page-render time, this shoves the render request into an unwieldy, grotesquely-long URL that encodes the render request state, and then the `_async` image handler is responsible for generating the render request from that.

This uses signed URLs to avoid situations where someone may construct a malicious render request externally. The downside is that in a load-balanced scenario, this requires that all backing instances use the same `app.secret_key` or that the load balancer provides strong connection affinity, but that's currently the case for all user authentication as well.

## Developer/user impact

There should be no impact on users, aside from some edge cases where images will fail to load if a page is requested immediately before a Publ deployment occurs but before the images get rendered.

## Test plan

Unit tests continue to pass, and manually removed the `tests/static/_img` directory to smoke-test various scenarios.

## Got a site to show off?

<!-- If so, link to it here! -->
