### PR TITLE
Handle date-related exceptions on entry parsing more broadly

### DIFF
--- a/publ/image/local.py
+++ b/publ/image/local.py
@@ -57,6 +57,7 @@ RENDITION_ARG_FILTER = {
     'quantize',
 }
 
+
 def fix_orientation(image: PIL.Image) -> PIL.Image:
     """ adapted from https://stackoverflow.com/a/30462851/318857
 
@@ -325,9 +326,9 @@ class LocalImage(Image):
             return flask.url_for(
                 'async',
                 render_spec=signer.dumps(
-                                     (self._record.file_path, output_scale, 
-                                     {k:v for k,v in kwargs.items() if k in RENDITION_ARG_FILTER})),
-                                 _external=kwargs.get('absolute')), size
+                    (self._record.file_path, output_scale,
+                     {k: v for k, v in kwargs.items() if k in RENDITION_ARG_FILTER})),
+                _external=kwargs.get('absolute')), size
         return utils.static_url(out_rel_path, kwargs.get('absolute')), size
 
     def render_async(self, output_scale, **kwargs):

--- a/test_app.py
+++ b/test_app.py
@@ -59,7 +59,7 @@ config = {
         'max_width': 768,
     },
     'search_index': '_index' if whoosh else None,
-    'index_enable_watchdog': False,
+    'index_enable_watchdog': True,
 }
 
 app = publ.Publ(__name__, config)


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

On systems with a 32-bit `time_t`, `OverflowError` occurs when trying to set a date beyond the 32-bit rollover. This fixes #394 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

If soemone's still running Publ on a 32-bit system in 2038 they have bigger problems.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Unit tests pass, this is difficult to properly test on 64-bit systems though (and I don't have any 32-bit systems available to test on).

## Got a site to show off?

<!-- If so, link to it here! -->
