### PR TITLE
Restrict view(...) arguments to valid query filters

### DIFF
--- a/publ/view.py
+++ b/publ/view.py
@@ -78,22 +78,26 @@ class View(caching.Memoizable):
                 spec[pagination] = input_spec[pagination]
                 break
 
-        self._order_by = spec.get('order', 'newest')
+        self.spec = spec.copy()
 
-        self.spec = spec
+        self._order_by = spec.pop('order', 'newest').lower()
 
         if 'start' in spec and paginated:
             if self._order_by == 'oldest':
-                self.spec['first'] = self.spec['start']
+                spec['first'] = spec['start']
             elif self._order_by == 'newest':
-                self.spec['last'] = self.spec['start']
+                spec['last'] = spec['start']
+        spec.pop('start', None)
+
+
+        count = spec.pop('count', None)
 
         self._entries = queries.build_query(
             spec).order_by(*queries.ORDER_BY[self._order_by])
 
         if self.spec.get('date') is not None:
             _, self.type, _ = utils.parse_date(self.spec['date'])
-        elif 'count' in self.spec:
+        elif count is not None:
             self.type = 'count'
         else:
             self.type = ''

--- a/tests/templates/queries.html
+++ b/tests/templates/queries.html
@@ -30,13 +30,6 @@
 {% endfor %}
 </ul>
 
-<h2>id=None</h2>
-<ul>
-{% for item in get_view(id=None).entries %}
-<li>{{item.title}} ({{item.entry_type}})</li>
-{% endfor %}
-</ul>
-
 <h2>date=None</h2>
 <ul>
 {% for item in get_view(date=None).entries %}

--- a/tests/templates/test_invalid_filter_arg.html
+++ b/tests/templates/test_invalid_filter_arg.html
@@ -1,0 +1,1 @@
+{{view(invalid_arg=None)}}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
`view()` now only accepts filter parameters, rather than silently ignoring link parameters which should be given to `view().link` instead.

Fixes #506 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

There was an issue with how view-as-call-site accidentally made it too easy to pass in a silently-ignored parameter such as doing `<a href="{{view.previous(template='foo')}}>` instead of the (correct) `<a href="{{view.previous.link(template='foo')}}>`. This change ensures that only valid filter parameters get passed into the filter query.

This also finally refactored some fairly hairy, un-Pythonic code to be more Pythonic, so that's a nice bonus.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
Templates will no longer silently fail if a link parameter is being passed into a filter context. Any errors caused by this were actually errors before, they were just not visibly so.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Ran all of the related tests, and also added a `test_invalid_filter_arg` template which fails on purpose. Also tested it against the beesbuzz.biz templates, which identified a couple of issues on that site as well as verified some more advanced pagination behavior which doesn't currently have a test.

TODO: properly unit test stuff, seriously


## Got a site to show off?

<!-- If so, link to it here! -->
