### PR TITLE
Remove before_first_request dependency

### DIFF
--- a/publ/config.py
+++ b/publ/config.py
@@ -61,6 +61,9 @@ class _Defaults:
     # Full-text search directory
     search_index = None
 
+    # security secret key
+    secret_key = None
+
 
 class Config(_Defaults):
     """ Stores configuration for a Publ app """

--- a/test_app.py
+++ b/test_app.py
@@ -60,11 +60,10 @@ config = {
     },
     'search_index': '_index' if whoosh else None,
     'index_enable_watchdog': True,
+    'secret_key': "We are insecure",
 }
 
 app = publ.Publ(__name__, config)
-app.secret_key = "We are insecure"
-
 
 @app.route('/favicon.<ext>')
 def favicon(ext):


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Remove the dependence on the now-deprecated `Flask.before_first_request` functionality; fixes #500 

## Detailed description

Flask 2.3 removed `before_first_request`, which Publ used as a hook for two purposes:

1. Configuring Authl
2. Deferring the content indexer until the first request, when running in debug mode

Purpose 2 was a workaround to a bug in Flask's hot-reload functionality that has been since fixed, and purpose 1 was something I went back and forth a few times on how the `secret_key` should be configured in the first place; originally I wanted it to be an up-front config value but that led to some inconsistencies with Flask's API.

Anyway, the removal of `before_first_request` forced the issue and since there's now a security vulnerability against Flask 2.2, an upgrade to 2.3 was required, so this fixes that.

## Developer/user impact

Any Publ site that makes use of Authl now needs its authentication key to be passed in as a `"secret_key"` value in the configuration `dict`; if this is not done, authentication will not be configured.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Manually tested by not updating `test_app.py`, then fixing `test_app.py`. Both behaved correctly.

## Got a site to show off?

<!-- If so, link to it here! -->
