### PR TITLE
Improve first paragraph filter and expose as a Jinja filter

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -1015,6 +1015,7 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], fixup_pass: int) -> 
 @orm.db_session
 def expire_record(record):
     """ Expire a record for a missing entry """
+    from .flask_wrapper import current_app
 
     # This entry no longer exists so delete anything that relies on it
     orm.delete(pa for pa in model.PathAlias if pa.entry == record)
@@ -1031,11 +1032,12 @@ def expire_record(record):
 @orm.db_session
 def remove_by_path(fullpath: str, entry_id: int):
     """ Remove entries for a path that don't match the expected ID """
+    from .flask_wrapper import current_app
 
     # remove fulltext search entries
-    for fte in orm.select(e for e in model.Entry
-        if e.file_path == fullpath
-        and e.id != entry_id):
+    for fte in orm.select(e for e in model.Entry  # type:ignore
+                          if e.file_path == fullpath
+                          and e.id != entry_id):
         current_app.search_index.remove(fte.id)
 
     orm.delete(pa for pa in model.PathAlias  # type:ignore
@@ -1045,5 +1047,3 @@ def remove_by_path(fullpath: str, entry_id: int):
                if e.file_path == fullpath
                and e.id != entry_id)
     orm.commit()
-
-

--- a/publ/flask_wrapper.py
+++ b/publ/flask_wrapper.py
@@ -136,7 +136,8 @@ class Publ(flask.Flask):
             secure_url=utils.secure_link,
         )
 
-        self.jinja_env.filters['strip_html'] = html_entry.strip_html  # pylint: disable=no-member
+        self.jinja_env.filters['strip_html'] = html_entry.strip_html
+        self.jinja_env.filters['first_paragraph'] = html_entry.first_paragraph
 
         caching.init_app(self, self.publ_config.cache)
 

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -19,6 +19,7 @@ HTML_PLAINTEXT_ELEMENTS = (
     'kbd', 'label', 'q', 'samp', 'span', 'strong', 'sub', 'sup', 'time', 'tt',
     'var', 'mark', 'p')
 
+
 class HTMLEntry(utils.HTMLTransform):
     """ An HTML manipulator to fixup src and href attributes """
 
@@ -204,9 +205,9 @@ class FirstParagraph(utils.HTMLTransform):
         super().__init__()
         self._strip_tag = strip_tag
 
-        self._found = False # has text been consumed?
-        self._done = False # have we finished a paragraph?
-        self._tag_stack = [] # tuple of tag, consume data, close tag
+        self._found = False  # has text been consumed?
+        self._done = False  # have we finished a paragraph?
+        self._tag_stack = []  # tuple of tag, consume data, close tag
 
     @property
     def consuming(self):
@@ -255,6 +256,7 @@ class FirstParagraph(utils.HTMLTransform):
                 self._found = True
             self.append(data)
 
+
 def first_paragraph(text, markup=True, strip_tag=False):
     """ Extract the first paragraph of text from an HTML document """
     first_para = FirstParagraph(strip_tag=strip_tag)
@@ -262,5 +264,4 @@ def first_paragraph(text, markup=True, strip_tag=False):
     text = first_para.get_data()
     if markup:
         return markupsafe.Markup(text)
-    else:
-        return strip_html(text)
+    return strip_html(text)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -29,7 +29,7 @@ TocBuffer = typing.List[TocEntry]
 TOC_ALLOWED_TAGS = ('sup', 'sub',
                     'em', 'strong',
                     'b', 'i',
-                    'code',
+                    'code', 'tt',
                     'del', 'add', 'mark')
 
 # Remove these tags from plaintext-style conversions

--- a/publ/search.py
+++ b/publ/search.py
@@ -111,6 +111,7 @@ class SearchIndex:
 
     @property
     def active(self):
+        """ Return whether the search index is active """
         return self.index is not None
 
     def update(self, record: model.Entry,

--- a/publ/search.py
+++ b/publ/search.py
@@ -109,7 +109,12 @@ class SearchIndex:
 
         self.query_parser = whoosh.qparser.QueryParser("content", self.index.schema)
 
-    def update(self, record: model.Entry, entry_file: email.message.EmailMessage):
+    @property
+    def active(self):
+        return self.index is not None
+
+    def update(self, record: model.Entry,
+               entry_file: typing.Optional[email.message.EmailMessage]):
         """
         Add an entry to the content index
         """
@@ -126,11 +131,17 @@ class SearchIndex:
             writer.update_document(
                 entry_id=str(record.id),
                 title=record.title,
-                content=entry_file.get_payload(),
+                content=entry_file.get_payload() if entry_file else '',
                 published=datetime.datetime.fromtimestamp(record.utc_timestamp),
-                tag=','.join(entry_file.get_all('tag') or []),
+                tag=','.join(entry_file.get_all('tag') or []) if entry_file else '',
                 category=record.category,
                 status=record.status)
+
+    def remove(self, entry_id: int):
+        """ Remove an entry by ID """
+        if not self.index:
+            return
+        self.index.delete_by_term("entry_id", str(entry_id))
 
     def query(self, query: str,
               category=None, recurse=False,

--- a/tests/content/cards/list in summary.md
+++ b/tests/content/cards/list in summary.md
@@ -1,0 +1,9 @@
+Title: List in summary
+Date: 2023-05-22 13:13:51-07:00
+Entry-ID: 984
+UUID: 290cb89b-4769-5da4-93b0-d84cd4b22bca
+
+* Testing [issue 497](https://github.com/PlaidWeb/Publ/issues/497)
+* These bullet points should not appear in the summary
+
+This text should appear in the summary.

--- a/tests/templates/first-paragraph.html
+++ b/tests/templates/first-paragraph.html
@@ -1,0 +1,25 @@
+<h1>First paragraphs only</h1>
+
+<h2>Strip HTML</h2>
+
+<ul>
+{% for entry in view.entries %}
+<li><a href="{{entry.link}}">{{entry.title}}</a>: {{entry.body|first_paragraph(markup=False)}}</li>
+{% endfor %}
+</ul>
+
+<h2>Strip paragraph</h2>
+
+<ul>
+{% for entry in view.entries %}
+<li><a href="{{entry.link}}">{{entry.title}}</a>: {{entry.body|first_paragraph(strip_tag=True)}}</li>
+{% endfor %}
+</ul>
+
+<h2>Passthrough</h2>
+
+<ul>
+{% for entry in view.entries %}
+<li><a href="{{entry.link}}">{{entry.title}}</a>: {{entry.body|first_paragraph}}</li>
+{% endfor %}
+</ul>

--- a/tests/test_html_entry.py
+++ b/tests/test_html_entry.py
@@ -107,16 +107,26 @@ def test_first_paragraph():
 
     processor = FirstParagraph()
     processor.feed('<div class="images"><img src="foo"></div>Bare text<p>foo</p>')
-    assert processor.get_data() == '<div class="images"><img src="foo"></div>Bare text'
+    assert processor.get_data() == 'Bare text'
 
     processor = FirstParagraph()
     processor.feed('<p><img src="foo"></p><p>Para 1</p>')
-    assert processor.get_data() == '<p><img src="foo"></p><p>Para 1</p>'
+    assert processor.get_data() == '<p></p><p>Para 1</p>'
 
     processor = FirstParagraph()
     processor.feed('<h1>Head<i>ing</i></h1>Bare text')
-    assert processor.get_data() == '<h1>Head<i>ing</i></h1>'
+    assert processor.get_data() == 'Bare text'
 
     processor = FirstParagraph()
     processor.feed('<h1><b>Heading with bad nesting</h2>Bare text')
-    assert processor.get_data() == '<h1><b>Heading with bad nesting</h2>'
+    assert processor.get_data() == 'Bare text'
+
+
+def test_first_paragraph_filter():
+    from publ.html_entry import first_paragraph
+
+    assert first_paragraph("<p>this is a thing</p>") == "<p>this is a thing</p>"
+    assert first_paragraph("<p>this is <em>a</em> thing</p>",
+                           strip_tag=True) == "this is <em>a</em> thing"
+    assert first_paragraph("this is <em>a</em> thing",
+                           markup=False) == "this is a thing"


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes the way that we extract the first paragraph, and exposes a filter to the Jinja templating engine.

Fixes #497 

## Detailed description

Rewrote the `html_entry.FirstParagraph` thing to correctly filter out all non-inline content, and also added `markup` and `strip_tag` parameters to the `html_entry.first_paragraph` function. This also exposes said function as a Jinja template filter, with optional parameters of `markup=True` (keep internal markup) and `strip_tag=False` (remove outermost `<p>` tag(s)).

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

This now strips non-paragraph text from entry summaries, including headings, list items, and so on.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Added unit test to `test_html_entry.py` and ad-hoc test suite in the `/first-paragraph` template.

## Got a site to show off?

<!-- If so, link to it here! -->
