### PR TITLE
Ignore entry parts which are just whitespace

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -312,7 +312,7 @@ class Entry(caching.Memoizable):
         _, ext = os.path.splitext(self._record.file_path)
         is_markdown = ext == '.md'
 
-        return body, more, is_markdown
+        return body.strip(), more.strip(), is_markdown
 
     @cached_property
     def body(self) -> typing.Callable[..., str]:

--- a/tests/content/bodybool/_.cat
+++ b/tests/content/bodybool/_.cat
@@ -1,0 +1,1 @@
+Name: Body part booleans

--- a/tests/content/bodybool/big empty body more.md
+++ b/tests/content/bodybool/big empty body more.md
@@ -1,0 +1,14 @@
+Title: Big empty body, plus more text
+Date: 2023-05-23 00:11:29-07:00
+Entry-ID: 403
+UUID: f4cfb5fd-1eab-5705-86e1-d54aae5fa863
+
+
+
+
+
+
+
+
+.....
+more text

--- a/tests/content/bodybool/body only.md
+++ b/tests/content/bodybool/body only.md
@@ -1,0 +1,6 @@
+Title: Body only
+Date: 2023-05-23 00:10:59-07:00
+Entry-ID: 408
+UUID: 8e8a41d6-c01e-5850-bdde-3692e2b72a66
+
+This is a body

--- a/tests/content/bodybool/body separator.md
+++ b/tests/content/bodybool/body separator.md
@@ -1,0 +1,8 @@
+Title: Body, separator, nothing else
+Date: 2023-05-23 00:11:50-07:00
+Entry-ID: 489
+UUID: e5593351-01d9-568f-b7e1-ecbc7006a4ea
+
+this is the body
+
+.....

--- a/tests/content/bodybool/fully empty.md
+++ b/tests/content/bodybool/fully empty.md
@@ -1,0 +1,5 @@
+Title: Fully empty file
+Date: 2023-05-23 00:10:29-07:00
+Entry-ID: 246
+UUID: bcbdf906-1c52-5c50-8889-7770506aabb2
+

--- a/tests/content/bodybool/more only.md
+++ b/tests/content/bodybool/more only.md
@@ -1,0 +1,7 @@
+Title: More only
+Date: 2023-05-23 00:11:09-07:00
+Entry-ID: 816
+UUID: 3c25e22d-7bee-5070-9395-331b5899943e
+
+.....
+This is more text

--- a/tests/content/bodybool/separator whitespace.md
+++ b/tests/content/bodybool/separator whitespace.md
@@ -1,0 +1,18 @@
+Title: Separator with lots of whitespace
+Date: 2023-05-23 00:12:14-07:00
+Entry-ID: 146
+UUID: ea724ce5-28ad-5933-8f72-4cd7975ea280
+
+
+.....
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/content/bodybool/whitespace.md
+++ b/tests/content/bodybool/whitespace.md
@@ -1,0 +1,17 @@
+Title: File with lots of whitespace
+Date: 2023-05-23 00:10:42-07:00
+Entry-ID: 461
+UUID: 319a0f26-3e52-5b2f-b875-b944e26dd703
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/templates/bodybool/index.html
+++ b/tests/templates/bodybool/index.html
@@ -1,0 +1,5 @@
+<ul>
+{% for entry in view.entries %}
+<li><a href="{{entry.link}}">{{entry.title}}</a>: body:{{entry.body and "yes" or "no"}} more:{{entry.more and "yes" or "no"}}</li>
+{% endfor %}
+</li>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Make whitespace-only entry parts not count as truthy

## Detailed description

On my site, sometimes files with a lot of whitespace sneak in, and end up causing the wrong layout rules to trigger (for example, with reaction posts). This change ensures that sections which are just whitespace appear as empty instead.

## Developer/user impact

If someone's actually relying on whitespace appearing as a valid empty section, they'll need to put in an `&nbsp;` or similar.

## Test plan

See test suite in `/bodybool`

## Got a site to show off?

<!-- If so, link to it here! -->
