### PR TITLE
Enable cache-control for requests that aren't user-dependent

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -501,6 +501,8 @@ class Entry(caching.Memoizable):
     @property
     def authorized(self) -> bool:
         """ Returns if the current user is authorized to see this entry """
+        if self._record.auth:
+            flask.g.user_dependent = True
         return self._record.is_authorized(user.get_active())
 
     def _get_markup(self, text, is_markdown, args,

--- a/publ/user.py
+++ b/publ/user.py
@@ -87,11 +87,13 @@ class User(caching.Memoizable):
     @cached_property
     def identity(self):
         """ The federated identity name of the user """
+        flask.g.user_dependent = True
         return self._identity
 
     @cached_property
     def humanize(self) -> str:
         """ A humanized version of the identity string """
+        flask.g.user_dependent = True
         url = self.profile.get('profile_url', self._identity)
         parsed = urllib.parse.urlparse(url)
         return ''.join(p for p in (
@@ -103,6 +105,7 @@ class User(caching.Memoizable):
     @cached_property
     def name(self) -> str:
         """ The readable name of the user """
+        flask.g.user_dependent = True
         if 'name' in self.profile:
             return self.profile['name']
 
@@ -111,21 +114,25 @@ class User(caching.Memoizable):
     @property
     def profile(self) -> dict:
         """ Get the user's profile """
+        flask.g.user_dependent = True
         return self._info[0]
 
     @cached_property
     def groups(self) -> typing.Set[str]:
         """ The group memberships of the user, for display purposes """
+        flask.g.user_dependent = True
         return get_groups(self._identity, False)
 
     @cached_property
     def auth_groups(self) -> typing.Set[str]:
         """ The group memberships of the user, for auth purposes """
+        flask.g.user_dependent = True
         return get_groups(self._identity, True)
 
     @cached_property
     def is_admin(self) -> bool:
         """ Returns whether this user has administrator permissions """
+        flask.g.user_dependent = True
         return bool(config.admin_group and config.admin_group in self.auth_groups)
 
     @cached_property
@@ -168,6 +175,7 @@ class User(caching.Memoizable):
 
     def token(self, lifetime: int, scope: Optional[str] = None) -> str:
         """ Get a bearer token for this user """
+        flask.g.user_dependent = True
         return tokens.get_token(self.identity, lifetime, scope)
 
 

--- a/test_app.py
+++ b/test_app.py
@@ -37,7 +37,8 @@ config = {
         'CACHE_THRESHOLD': 20
     } if os.environ.get('TEST_CACHING') else {
         'CACHE_TYPE': 'NullCache',
-        'CACHE_NO_NULL_WARNING': True
+        'CACHE_NO_NULL_WARNING': True,
+        'CACHE_DEFAULT_TIMEOUT': 720
     },
     'auth': {
         'TEST_ENABLED': True,
@@ -71,7 +72,7 @@ def favicon(ext):
     """ render a favicon """
     logo = publ.image.get_image('images/rawr.jpg', 'tests/content')
     img, _ = logo.get_rendition(format=ext, width=128, height=128, resize='fill')
-    return flask.redirect(img)
+    return flask.redirect(img), {'Cache-Control': 'public, max-age=86400'}
 
 
 @app.path_alias_regex(r'(.*)/date/([0-9]+)')


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Set a cache-control header based on whether the page makes use of user identity; fixes #525 


## Detailed description

If a page doesn't make use of entry authentication, or doesn't request stuff from the current userinfo, set a cache-control header that allows caching.

If the page does use entry authentication or does request stuff from userinfo, disallow caching.

There is a slight gap in that there's no way to tell if userinfo was requested if there is no logged-in user. However, in manual smoke tests, Firefox seems to discard cache entries once the user logs in, likely because of `Vary:Cookie` behavior, so this is probably a non-issue (and to that end it might actually be safe to always set cache-control with `private, max-age=NNN`).

max-age will be set based on the server-side caching configuration, with a default of 1 hour otherwise.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->
Might require users to shift-reload in some circumstances.

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
Manual smoke testing with `curl -i` and the firefox console. Verified that non-user-dependent and non-authentication-needed pages return a `cache-control: public, max-age=NNN` and any page that either retrieved userinfo or checked entry auth returned `cache-control: private`.

## Got a site to show off?

<!-- If so, link to it here! -->
