### PR TITLE
Set same-site cookie policy

### DIFF
--- a/publ/flask_wrapper.py
+++ b/publ/flask_wrapper.py
@@ -154,6 +154,10 @@ class Publ(flask.Flask):
             tmpl = rendering.map_template('/', 'logout')
             return rendering.render_publ_template(tmpl)[0]
 
+        self.config.update(
+            SESSION_COOKIE_HTTPONLY=True,
+            SESSION_COOKIE_SAMESITE='Lax')
+
         if self.auth:
             for route in [
                     '/_logout',

--- a/tests/content/auth/userinfo-embed.md
+++ b/tests/content/auth/userinfo-embed.md
@@ -1,0 +1,8 @@
+Title: show userinfo as embed
+Date: 2023-05-23 03:39:55-07:00
+Entry-ID: 615
+UUID: b6739af6-ebf3-59a9-894c-eb938c044fce
+
+Test the caching nature of the userinfo page
+
+<iframe src="/userinfo"></iframe>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #524 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
Sets the same-site cookie policy to `Lax` and also disables access to the session cookie via JavaScript, providing better clickjack mitigation.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
