### PR TITLE
Properly redirect malformed empty category URLs

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -311,8 +311,10 @@ def render_category_path(category: str, template: typing.Optional[str]):
         # this might actually be a malformed category URL
         test_path = '/'.join((category, template_name)) if category else template_name
         LOGGER.debug("Checking for malformed category %s", test_path)
-        record = model.Entry.select(lambda e: e.category ==
-                                    test_path and e.visible).exists()  # type:ignore
+        record = model.Entry.select(
+            lambda e: (e.category == test_path
+                       or e.category.startswith(f'{test_path}/'))
+            and e.visible).exists()  # type:ignore
         if record:
             LOGGER.debug("Redirecting to category %s; request.args=%s", test_path, request.args)
             return redirect(url_for('category', category=test_path,

--- a/tests/content/emptycat/subcat/entry.md
+++ b/tests/content/emptycat/subcat/entry.md
@@ -1,0 +1,4 @@
+Date: 2023-09-01 13:09:12-07:00
+Entry-ID: 421
+UUID: 9505dea0-cfdf-5890-ae98-71e9cbc6a8d5
+


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
Properly redirect on a category with no content but with subcategory content when given a non-`/`-terminated URL. Fixes #545 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->
When checking to see if a URL is a malformed category URL, also accept it if there are matching subcategories. For example, `http://example.com/emptycat` redirects to `https://example.com/emptycat/` if there are valid entries within the `/emptycat/subcat` category.

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
See the simple `/emptycat` test.

## Got a site to show off?

<!-- If so, link to it here! -->
