### PR TITLE
Update dependencies and delint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1676,4 +1676,4 @@ search = ["Whoosh"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "7984455c7ab9fc9f42df5e111751bd866c951c824f7f77486c9c75dca0bd7a12"
+content-hash = "50bfbd32cb9ec704067b0f9a9cb8ba1f18a777f79e7d1daa1a77c6c0c5db51ed"

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -301,7 +301,8 @@ class Entry(caching.Memoizable):
         if not self.authorized:
             return '', '', False
 
-        body, _, more = self._message.get_payload().partition('\n.....\n')
+        payload = typing.cast(str, self._message.get_payload())
+        body, _, more = payload.partition('\n.....\n')
         if not more and body.startswith('.....\n'):
             # The entry began with a cut, which failed to parse.
             # This rule is easier/faster than dealing with a regex from

--- a/publ/flask_wrapper.py
+++ b/publ/flask_wrapper.py
@@ -166,7 +166,6 @@ class Publ(flask.Flask):
             import uuid
             self.secret_key = uuid.uuid4().hex
 
-
         if self.auth:
             for route in [
                     '/_logout',

--- a/publ/image/local.py
+++ b/publ/image/local.py
@@ -46,7 +46,7 @@ OPTIMIZE_FORMATS = {'.jpg', '.jpeg', '.png'}
 # arguments that affect the final rendition
 
 
-def fix_orientation(image: PIL.Image) -> PIL.Image:
+def fix_orientation(image: PIL.Image.Image) -> PIL.Image.Image:
     """ adapted from https://stackoverflow.com/a/30462851/318857
 
         Apply Image.transpose to ensure 0th row of pixels is at the visual
@@ -72,7 +72,7 @@ def fix_orientation(image: PIL.Image) -> PIL.Image:
 
     try:
         # pylint:disable=protected-access
-        orientation = image._getexif()[exif_orientation_tag]
+        orientation = image.getexif()[exif_orientation_tag]
         sequence = exif_transpose_sequences[orientation]
         return functools.reduce(type(image).transpose, sequence, image)
     except (TypeError, AttributeError, KeyError):
@@ -239,7 +239,8 @@ class LocalImage(Image):
 
             if 'scale_filter' in kwargs:
                 try:
-                    scale_filter = getattr(PIL.Image.Resampling, kwargs['scale_filter'].upper())
+                    scale_filter = getattr(PIL.Image.Resampling,
+                                           kwargs['scale_filter'].upper())
                     label += f'f{scale_filter}'
                 except AttributeError as error:
                     raise ValueError(

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -12,8 +12,8 @@ import werkzeug.exceptions as http_error
 from flask import redirect, request, send_file, url_for
 from pony import orm
 
-from . import (caching, image, index, model, path_alias, queries,
-               user, utils, view)
+from . import (caching, image, index, model, path_alias, queries, user, utils,
+               view)
 from .caching import cache
 from .category import Category
 from .config import config

--- a/publ/view.py
+++ b/publ/view.py
@@ -97,7 +97,7 @@ class View(caching.Memoizable):
         self._deleted = queries.build_query({
             **spec,
             '_deleted': True
-            }).order_by(*queries.ORDER_BY[self._order_by])
+        }).order_by(*queries.ORDER_BY[self._order_by])
         self._entries = queries.build_query(
             spec).order_by(*queries.ORDER_BY[self._order_by])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Publ"
-version = "0.7.28"
+version = "0.7.29"
 description = "A flexible web-based publishing framework"
 authors = ["fluffy <fluffy@beesbuzz.biz>"]
 license = "MIT"
@@ -24,7 +24,7 @@ pony = "^0.7.16"
 Pygments = "^2.15.1"
 Whoosh = { version = "^2.7.4", optional = true }
 watchdog = "*"
-pillow = "^10.1.0"
+pillow = "^10.3.0"
 requests = "^2.31.0"
 
 [tool.poetry.extras]


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Update dependencies and then fix some linting and typing issues that came from changes

## Detailed description

`email.message`'s `get_payload()` is now variadic; for now we just assume it's a `str` although this will probably break in the future.

`PIL.Image`'s typing situation has gotten stricter as of 10.3.0, so this forces version 10.3 as a minimum and also fixes it to use the correct object typename. 10.3 also finally promoted `_getexif` to a public API.

