### PR TITLE
Add direct entry retrieval and relative image fetching

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -300,6 +300,11 @@ class Category(caching.Memoizable):
         """ Get the name of the index template for this category """
         return self.get('Index-Template', 'index')
 
+    def image(self, filename):
+        """ Retrieve an image using our search path as the context """
+        return image.get_image(filename, (self.search_path,))
+
+
 
 @orm.db_session(retry=5)
 def scan_file(fullpath, relpath) -> bool:

--- a/publ/flask_wrapper.py
+++ b/publ/flask_wrapper.py
@@ -12,7 +12,7 @@ from werkzeug.utils import cached_property
 
 # pylint:disable=cyclic-import
 from . import (caching, cli, config, html_entry, image, index, maintenance,
-               model, rendering, search, tokens, user, utils, view)
+               model, rendering, search, tokens, user, utils, view, entry)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -130,6 +130,7 @@ class Publ(flask.Flask):
             arrow=arrow,
             static=utils.static_url,
             get_template=rendering.get_template,
+            get_entry=entry.get_entry_by_id,
             login=utils.auth_link('login'),
             logout=utils.auth_link('logout'),
             token_endpoint=utils.CallableProxy(lambda: utils.secure_link('tokens')),

--- a/publ/template.py
+++ b/publ/template.py
@@ -8,7 +8,7 @@ import typing
 import arrow
 import flask
 
-from . import utils
+from . import utils, image
 from .config import config
 
 EXT_PRIORITY = ['', '.html', '.htm', '.xml', '.json', '.txt']
@@ -64,6 +64,12 @@ class Template:
 
     def __hash__(self):
         return hash(self._key())
+
+    def image(self, filename):
+        """ Retrieve an image using our search path as the context """
+        search_path = (os.path.join(config.content_folder, os.path.dirname(self.filename)),)
+        return image.get_image(filename, search_path)
+
 
 
 def map_template(category: str,

--- a/tests/templates/entry-retrieval.html
+++ b/tests/templates/entry-retrieval.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Template entry lookups</title>
+</head>
+<body>
+
+{% set entry=get_entry(2271) %}
+<h1>Entry 2271: {{entry.title}}</h1>
+
+{{entry.body}}
+{{entry.more}}
+
+{{entry.image('construct.gif').get_img_tag()}}
+
+{% set entry=get_entry(107) %}
+{% if entry %}
+<h1>Entry {{entry.id}}: {{entry.title}}</h1>
+
+{{entry.body}}
+{{entry.more}}
+
+{{entry.image('construct.gif').get_img_tag()}}
+{% else %}
+Couldn't retrieve entry 107
+{% endif %}


### PR DESCRIPTION


<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Adds a `get_entry(id)` template function, and context-relative functions for doing entry-relative image retrieval

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

`get_entry` is a new function that allows retrieving a specific entry by entry ID, if available to the current user.

The `Entry`, `Category`, and `Template` classes now have an `image` method which allows retrieving an image from their respective contexts. This is useful for doing relative image resolution.

## Test plan

The template `entry-retrieval.html` retrieves two hardcoded entry IDs, and also attempts to resolve an image from both of them.

