### PR TITLE
Replace overwrought database ACL test with simple string parsing

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -843,7 +843,8 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], fixup_pass: int) -> 
         'redirect_url': entry.get('Redirect-To', ''),
         'title': title,
         'sort_title': entry.get('Sort-Title', title),
-        'canonical_path': entry.get('Path-Canonical', '')
+        'canonical_path': entry.get('Path-Canonical', ''),
+        'auth': entry.get('Auth', '')
     }
 
     entry_date = None
@@ -914,15 +915,6 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], fixup_pass: int) -> 
             path_alias.set_alias(alias, model.AliasType.MOUNT, entry=record)
         for alias in entry.get_all('Path-Canonical', []):
             path_alias.set_alias(alias, model.AliasType.MOUNT, entry=record)
-
-    orm.delete(p for p in model.EntryAuth if p.entry == record)  # type:ignore
-    orm.commit()
-    for order, user_group in enumerate(entry.get('Auth', '').split()):
-        allowed = user_group[0] != '!'
-        if not allowed:
-            user_group = user_group[1:]
-        model.EntryAuth(order=order, entry=record, user_group=user_group, allowed=allowed)
-    orm.commit()
 
     with orm.db_session:
         set_tags = {


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Just parse the entry ACL rules from a string instead of trying to be too fancy in the database

## Detailed description

Profiling my website found that a *large* amount of the template render time was spent in the pagination, and that in turn was spending a *large* amount of time processing the permission ACL, which in turn required a lot of overly-complicated database access. There is no reason for this to be in the database when it's faster to just parse the ACL string directly instead of having to do a lot of marshaling, indexing, and so on.

## Developer/user impact

Bumps the schema, so sites will have to reindex.

## Test plan

Thoroughly tested using the `auth/` test suite.

## Got a site to show off?

<!-- If so, link to it here! -->
