### PR TITLE
Speed up auth filtering by many orders of magnitude

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -705,7 +705,10 @@ class Entry(caching.Memoizable):
         # so we need to retrieve chunk-wise
         start = 0
         if count is None:
-            # We're going to do a full table retrieval anyway so let's just do it
+            # We're going to do a full query retrieval (either due to lack of
+            # view constraint or using a date-based constraint), so we'd might
+            # as well just go for it instead of trying to be too fancy with
+            # clever loop conditionals
             count = len(entries)
         chunk_size = max(16, count)
 

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -705,14 +705,15 @@ class Entry(caching.Memoizable):
         # so we need to retrieve chunk-wise
         start = 0
         if count is None:
+            # We're going to do a full table retrieval anyway so let's just do it
             count = len(entries)
         chunk_size = max(16, count)
 
         while len(result) < count:
             chunk = entries[start:start + chunk_size]
+            start += chunk_size
 
             if not chunk:
-                # we're out of entries to consume
                 break
 
             for record in chunk:
@@ -726,8 +727,6 @@ class Entry(caching.Memoizable):
                         unauthorized -= 1
                 if not auth:
                     tokens.request(cur_user)
-
-            start += len(chunk)
 
         return result
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Remove some full-table scans for authorization checks

## Detailed description

It turns out that Pony's "lazy loading" of query results will immediately realize the entire query into a list at the drop of a hat, and you really need to use LIMIT and OFFSET to prevent that from happening.

Because of how authorization filtering works in Publ, count-based paginations were not using LIMIT and OFFSET. Now they are, and this has sped up rendering the global Atom feed on beesbuzz.biz by a significant factor.

Many huge thanks to @BearPerson / @AlsoBearPerson for helping me to figure out what was going on here, and being way more tenacious about digging through Pony than I am.

## Test plan

Ensured that the paging and auth/paging test suites still behave correctly.

## Got a site to show off?

<!-- If so, link to it here! -->
