### PR TITLE
Properly support HTTP Accept: and remove the ad-hoc template priority

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -23,15 +23,6 @@ from .template import Template, map_template
 
 LOGGER = logging.getLogger(__name__)
 
-# mapping from template extension to MIME type; probably could be better
-EXTENSION_MAP = {
-    '.html': 'text/html; charset=utf-8',
-    '.xml': 'application/xml',
-    '.json': 'application/json',
-    '.css': 'text/css; charset=utf-8',
-    '.txt': 'text/plain; charset=utf-8'
-}
-
 # Headers for responses that shouldn't be cached
 NO_CACHE = {
     'Cache-control': 'private, no-cache, no-store, max-age=0',
@@ -54,8 +45,7 @@ def cache_control():
 
 def mime_type(template: Template) -> str:
     """ infer the content-type from the extension """
-    _, ext = os.path.splitext(template.filename)
-    return EXTENSION_MAP.get(ext, 'text/html; charset=utf-8')
+    return f'{template.mime_type}; charset=utf-8'
 
 
 def get_template(template: str, relation) -> typing.Optional[str]:
@@ -157,6 +147,7 @@ def render_publ_template(template: Template, is_error=True, **kwargs) -> typing.
             _index_time=index.last_indexed(),
             _latest=latest_entry(),
             _publ_version=__version__,
+            _accept_mime=flask.request.accept_mimetypes,
             **kwargs)
         return text, etag
     except queries.InvalidQueryError as err:

--- a/publ/template.py
+++ b/publ/template.py
@@ -23,7 +23,7 @@ BUILTIN_DIR = os.path.join(os.path.dirname(__file__), 'default_template')
 # A useful set of default priorities for clients that don't declare Accept (e.g. curl)
 DEFAULT_ACCEPT = ['text/html',
                   'application/rss+xml',
-                  'application/rss+atom',
+                  'application/atom+xml',
                   'application/xml',
                   'style/css',
                   'text/plain',

--- a/tests/content/accept header.md
+++ b/tests/content/accept header.md
@@ -1,0 +1,13 @@
+Title: `Accept:` header support
+Date: 2024-12-31 23:05:05-08:00
+Entry-ID: 3081
+UUID: f7be4ab6-6c0b-5987-a8cf-297c0d0b5ce6
+
+Some potential templates to look at, with different Accept: header values:
+
+* [Default](/accepts)
+* [accepts.html](/accepts.html) (`text/html`)
+* [accepts.htm](/accepts.htm) (`text/html`)
+* [accepts.atom](/accepts.atom) (`application/atom+xml`)
+* [accepts.txt](/accepts.txt) (`text/plain`)
+* [accepts.xml](/accepts.xml) (`application/xml`)

--- a/tests/templates/accepts.atom
+++ b/tests/templates/accepts.atom
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<feed xmlns="http://www.w3.org/2005/Atom"
+    xmlns:fh="http://purl.org/syndication/history/1.0"
+    xmlns:at="http://purl.org/atompub/tombstones/1.0">
+
+    <title>{{category.name}} Accept test</title>
+    <entry>
+        <id>urn:uuid:INVALID</id>
+        <content type="html">This is accepts.atom</content>
+    </entry>
+</feed>

--- a/tests/templates/accepts.htm
+++ b/tests/templates/accepts.htm
@@ -1,0 +1,1 @@
+<h1>This is accepts.htm</h1>

--- a/tests/templates/accepts.html
+++ b/tests/templates/accepts.html
@@ -1,0 +1,1 @@
+<h1>This is accepts.html</h1>

--- a/tests/templates/accepts.txt
+++ b/tests/templates/accepts.txt
@@ -1,0 +1,1 @@
+This is accepts.txt

--- a/tests/templates/accepts.xml
+++ b/tests/templates/accepts.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<info>This is accepts.xml</info>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Properly support HTTP `Accept:` and remove the ad-hoc template priority

Fixes #157 

## Detailed description

Instead of the ad-hoc MIME type and template mapping by extension nonsense, this change makes it so that the HTTP `Accept:` header drives the template selection logic. If a template is directly selected by full filename it'll still be used (and this will also override `Accept:` but if only a partial filename is given then it'll find the best match based on MIME types as determined by Python's [`mimetypes`](https://docs.python.org/3/library/mimetypes.html) library.

This makes it in particular such that you can provide feeds in different formats with e.g. `feed.rss` and `feed.atom` and `feed.html` and then depending on what the client is looking for, it'll map `feed` to the best-fitting one.

It also supports wildcard MIME types, and there is still an ad-hoc priority in place for clients which don't declare `Accept` since usually if you're doing `curl` on a thing there's still an expectation of getting e.g. HTML first. 

## Developer/user impact

There should be no impact on the MIME types chosen for the previously-declared things. However, all things are explicitly given a charset of `utf-8` which some non-conforming user-agents might not care for.

## Test plan

Added a test suite in the form of the `accepts.*` templates, which can be exercised with e.g.

```
curl http://localhost:5000/accept  # should serve accept.html
curl http://localhost:5000/accept.htm  # should serve accept.htm
curl http://localhost:5000/accept -H 'Accept: foo/bar'  # should result in a 406 error
```

## Got a site to show off?

<!-- If so, link to it here! -->
