### PR TITLE
Add status:ATTACHMENT

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -561,7 +561,8 @@ class Entry(caching.Memoizable):
 
         def _get_attachments(order=None, **kwargs) -> typing.List:
             query = queries.build_query({**kwargs,
-                                         'attachments': self._record
+                                         'attachments': self._record,
+                                         '_attachments': True,
                                          })
             if order:
                 query = query.order_by(*queries.ORDER_BY[order])
@@ -998,12 +999,13 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], fixup_pass: int) -> 
             other = links.find_entry(attach, search_path)
             if other:
                 set_attach.add(other)
-            elif fixup_pass < 3:
+            elif fixup_pass < 5:
                 # The entry hasn't been found, so treat this as a fixup task
                 # Pass 0 - this entry might not have an ID
                 # Pass 1 - the other entry might not have an ID (since this can be scheduled
                 #    before pass 1 of the other entry)
                 # Pass 2 - everything should have an ID now
+                # Then we give it a few extra passes for safety's sake
                 LOGGER.info("Attempted to link to unknown entry '%s -> %s'; retrying",
                             relpath, attach)
                 result = False

--- a/publ/index.py
+++ b/publ/index.py
@@ -148,7 +148,7 @@ class Indexer:
                 return False
 
         result = do_scan()
-        if result is False and fixup_pass < 5:
+        if result is False and fixup_pass < 10:
             LOGGER.info("Scheduling fixup pass %d for %s", fixup_pass + 1, fullpath)
             self.scan_file(fullpath, relpath, fixup_pass + 1)
         else:

--- a/publ/model.py
+++ b/publ/model.py
@@ -46,6 +46,9 @@ class PublishStatus(Enum):
 
     TEAPOT = 6      # RFC 2324
 
+    ATTACHMENT = 7  # Entry should only be visible in an attachment context
+    ATTACH = 7      # Synonym for ATTACHMENT
+
 
 class AliasType(Enum):
     """ The type of PathAlias mapping """
@@ -103,7 +106,8 @@ class Entry(DbEntity):
         """ Returns true if the entry should be viewable """
         return self.status in (PublishStatus.HIDDEN.value,
                                PublishStatus.PUBLISHED.value,
-                               PublishStatus.SCHEDULED.value)
+                               PublishStatus.SCHEDULED.value,
+                               PublishStatus.ATTACHMENT.value)
 
     def is_authorized(self, user) -> bool:
         """ Returns whether the entry is visible to the specified user """

--- a/tests/content/attach/main.md
+++ b/tests/content/attach/main.md
@@ -3,6 +3,7 @@ Date: 2020-05-17 16:37:14-07:00
 UUID: 65e871c6-0c4f-5dca-98a0-765c329d85f9
 Attach: supplement 1.md
 Attach: auth.md
+Attach: status-attachment.md
 Attach: 1349
 Entry-ID: 1208
 

--- a/tests/content/attach/status-attachment.md
+++ b/tests/content/attach/status-attachment.md
@@ -1,0 +1,7 @@
+Title: Only visible in an attachment context
+Status: ATTACHMENT
+Date: 2025-03-02 10:23:18-08:00
+Entry-ID: 2410
+UUID: a9138acf-0eb1-578e-aecd-74ffd8fcc30e
+
+This should never be visible from an index, and only from `entry.attachments` or similar.


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

<!-- Summary of the PR; please link to any issue(s) that this solves -->
If an entry has a status of ATTACHMENT (or ATTACH) it will only be visible from an attachment context (e.g. `entry.attachments`), and will never appear in a view.

Fixes #548 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
See `tests/attach/main.md` and `tests/attach/status-attachment.md`

## Got a site to show off?

<!-- If so, link to it here! -->
