### PR TITLE
Remove the async image renderer

### DIFF
--- a/publ/flask_wrapper.py
+++ b/publ/flask_wrapper.py
@@ -114,8 +114,8 @@ class Publ(flask.Flask):
         self.add_url_rule('/<path:path>.PUBL_PATHALIAS',
                           'path_alias', rendering.render_path_alias)
 
-        self.add_url_rule('/_async/<path:render_spec>',
-                          'async', image.get_async)
+        self.add_url_rule('/_img/<path:render_spec>',
+                          'get_image', image.render)
 
         self.add_url_rule('/_', 'chit', rendering.render_transparent_chit)
 

--- a/tests/content/images/image renditions.md
+++ b/tests/content/images/image renditions.md
@@ -12,29 +12,29 @@ Image rendition tests
 
 External image with width set
 
-![](//placekitten.com/800/600{250} "so smol")
+![](//placecats.com/800/600{250} "so smol")
 
-`![](//placekitten.com/800/600{250} "so smol")`
+`![](//placecats.com/800/600{250} "so smol")`
 
 External image with height set
 
-![](//placekitten.com/800/600{height=250} "less smol")
+![](//placecats.com/800/600{height=250} "less smol")
 
-`![](//placekitten.com/800/600{height=250} "less smol")`
+`![](//placecats.com/800/600{height=250} "less smol")`
 
 External image with width and height set, with different scaling modes:
 
 ![{320,320,div_class="gallery",gallery_id="sizing"}](
-//placekitten.com/960/480 "fit"
-| //placekitten.com/960/480{resize="fill"} "fill"
-| //placekitten.com/960/480{resize="stretch"} "stretch")
+//placecats.com/960/480 "fit"
+| //placecats.com/960/480{resize="fill"} "fill"
+| //placecats.com/960/480{resize="stretch"} "stretch")
 
 ```markdown
 
 ![{320,320,div_class="gallery",gallery_id="sizing"}](
-//placekitten.com/960/480 "fit"
-| //placekitten.com/960/480{resize="fill"} "fill"
-| //placekitten.com/960/480{resize="stretch"} "stretch")
+//placecats.com/960/480 "fit"
+| //placecats.com/960/480{resize="fill"} "fill"
+| //placecats.com/960/480{resize="stretch"} "stretch")
 ```
 
 Image using static path
@@ -46,9 +46,9 @@ Image using static path
 
 Force absolute URLs
 
-![{640,320,absolute=True}](//placekitten.com/800/600 | @images/IMG_0377.jpg | critter.webp{999,format='png'})
+![{640,320,absolute=True}](//placecats.com/800/600 | @images/IMG_0377.jpg | critter.webp{999,format='png'})
 
-`![{640,320,absolute=True}](//placekitten.com/800/600 | @images/IMG_0377.jpg | critter.webp{999,format='png'})`
+`![{640,320,absolute=True}](//placecats.com/800/600 | @images/IMG_0377.jpg | critter.webp{999,format='png'})`
 
 
 ## Local images
@@ -129,12 +129,12 @@ should still be in a paragraph
 ![such gallery{255,gallery_id="rawry"}](rawr.jpg
 | rawr.jpg{fullscreen_width=50} "Rawr!"
 | rawr.jpg{100}
-| //placekitten.com/1280/720)
+| //placecats.com/1280/720)
 
 ```markdown
 
 ![such gallery{255,gallery_id="rawry"}](rawr.jpg | rawr.jpg{fullscreen_width=50} "Rawr!" | rawr.jpg{100}
-| //placekitten.com/800/600)
+| //placecats.com/800/600)
 ```
 
 ## PNG transparency

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -47,7 +47,7 @@ def test_clean_cache():
         assert os.path.isfile(get_path('bar', 'qwer'))
 
         with app.app_context():
-            publ.image.clean_cache(7200).result()
+            publ.image.clean_cache(7200)
 
         LOGGER.debug("tempdir contents after purge:")
         for (path, _, files) in os.walk(tempdir):


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Removes the image rendering threadpool, switches to blocking image rendering.

Fixes #591

## Detailed description

The background rendering threadpool made sense in the early days of Publ when I was still trying to figure out how things should work, and when images were immediately rendered by the template itself. In the long run that has turned out not to be terribly helpful, and can actually cause massive performance and reliability issues in a lot of deployment scenarios.
