### PR TITLE
Fix the fixup mechanism with unknown attachments

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -1031,7 +1031,7 @@ def scan_file(fullpath: str, relpath: typing.Optional[str], fixup_pass: int) -> 
         LOGGER.info("Not touching draft entry %s", fullpath)
     elif fixup_needed:
         LOGGER.info("Fixing up entry %s", fullpath)
-        result = save_file(fullpath, entry, check_fingerprint)
+        result = result and save_file(fullpath, entry, check_fingerprint)
 
     # register with the search index
     current_app.search_index.update(record, entry)

--- a/tests/content/attach/fix-582/fix-1.md
+++ b/tests/content/attach/fix-582/fix-1.md
@@ -1,0 +1,5 @@
+Title: Test attachment 1
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 1963
+UUID: bb4fd154-410d-54a8-a3df-288a897b633d
+

--- a/tests/content/attach/fix-582/fix-10.md
+++ b/tests/content/attach/fix-582/fix-10.md
@@ -1,0 +1,5 @@
+Title: Test attachment 10
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 1337
+UUID: 07fc02d2-aa0c-5da2-bd45-a399fe010c37
+

--- a/tests/content/attach/fix-582/fix-2.md
+++ b/tests/content/attach/fix-582/fix-2.md
@@ -1,0 +1,5 @@
+Title: Test attachment 2
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 2309
+UUID: 36326ae2-b710-59a5-8be4-9fc092f68ee4
+

--- a/tests/content/attach/fix-582/fix-3.md
+++ b/tests/content/attach/fix-582/fix-3.md
@@ -1,0 +1,5 @@
+Title: Test attachment 3
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 1212
+UUID: ec0e72ea-5f79-5b04-bcbf-ce267890407f
+

--- a/tests/content/attach/fix-582/fix-4.md
+++ b/tests/content/attach/fix-582/fix-4.md
@@ -1,0 +1,5 @@
+Title: Test attachment 4
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 1351
+UUID: 5a83956b-017b-5512-abed-da46522ddd1e
+

--- a/tests/content/attach/fix-582/fix-5.md
+++ b/tests/content/attach/fix-582/fix-5.md
@@ -1,0 +1,5 @@
+Title: Test attachment 5
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 1200
+UUID: ed20c8c1-9c6c-5d97-8a76-778277f1a478
+

--- a/tests/content/attach/fix-582/fix-6.md
+++ b/tests/content/attach/fix-582/fix-6.md
@@ -1,0 +1,5 @@
+Title: Test attachment 6
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 2440
+UUID: da52552f-c1c8-59f8-94af-c0783232f280
+

--- a/tests/content/attach/fix-582/fix-7.md
+++ b/tests/content/attach/fix-582/fix-7.md
@@ -1,0 +1,5 @@
+Title: Test attachment 7
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 3211
+UUID: 06be1f43-5e74-57ce-bdd8-db9c17cb5f0e
+

--- a/tests/content/attach/fix-582/fix-8.md
+++ b/tests/content/attach/fix-582/fix-8.md
@@ -1,0 +1,5 @@
+Title: Test attachment 8
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 2348
+UUID: 4b368ec7-acfe-558b-8357-bef2a30b0f5b
+

--- a/tests/content/attach/fix-582/fix-9.md
+++ b/tests/content/attach/fix-582/fix-9.md
@@ -1,0 +1,5 @@
+Title: Test attachment 9
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 3406
+UUID: 3b4487a0-65c9-520b-a892-a5326f9b58dd
+

--- a/tests/content/attach/fix-582/root.md
+++ b/tests/content/attach/fix-582/root.md
@@ -1,0 +1,15 @@
+Title: Bulk attachment imports
+Attach: fix-1.md
+Attach: fix-2.md
+Attach: fix-3.md
+Attach: fix-4.md
+Attach: fix-5.md
+Attach: fix-6.md
+Attach: fix-7.md
+Attach: fix-8.md
+Attach: fix-9.md
+Attach: fix-10.md
+Date: 2025-03-02 12:03:53-08:00
+Entry-ID: 533
+UUID: dfa192bc-da99-55ad-b898-093b66ad269f
+


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Corrects an issue with first-index of new content with attachments; fixes #582 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

In the event that a new entry and its attachments were being imported and assigned IDs, oftentimes the indexer would miss the attachment relationship. This turned out to be a simple issue where the initial fixup pass (which assigned the entry ID) was overriding the next indexer pass (that would have added the attachment relationship to the database).

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

Generated a bunch of empty entries and their attachments all at once, in `content/attach/fix-582`. The attachment relationship was established by the end of the first index cycle.

## Got a site to show off?

<!-- If so, link to it here! -->
