### PR TITLE
Fix 403 error handling for the admin dashboard

### DIFF
--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -544,11 +544,11 @@ def admin_dashboard(by=None):  # pylint:disable=invalid-name
     cur_user = user.get_active()
 
     if not cur_user:
-        # Show a login page
-        return handle_unauthorized(cur_user)
+        # Show the login page
+        raise http_error.Unauthorized()
 
     if not cur_user.is_admin:
-        # go straight to 403 error
+        # Go straight to 403 error
         raise http_error.Forbidden("Insufficient access level")
 
     tmpl = map_template('', '_admin')

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -542,8 +542,14 @@ def render_entry_record(record: model.Entry, category: str, template: typing.Opt
 def admin_dashboard(by=None):  # pylint:disable=invalid-name
     """ Render the authentication dashboard """
     cur_user = user.get_active()
-    if not cur_user or not cur_user.is_admin:
+
+    if not cur_user:
+        # Show a login page
         return handle_unauthorized(cur_user)
+
+    if not cur_user.is_admin:
+        # go straight to 403 error
+        raise http_error.Forbidden("Insufficient access level")
 
     tmpl = map_template('', '_admin')
 

--- a/tests/templates/unauthorized.html
+++ b/tests/templates/unauthorized.html
@@ -1,0 +1,1 @@
+You are not authorized to see {{entry.link}}, sorry


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Don't attempt to render the `unauthorized` entry template on the admin dashboard; fixes #594 

## Detailed description

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

The `rendering.handle_unauthorized` flow only makes sense in an entry context, which the admin dashboard is not.


## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->
1. Test accessing `/_admin` as not-a-user, and log in as not-an-admin
2. Test it again logging in as an admin

## Got a site to show off?

<!-- If so, link to it here! -->
