### PR TITLE
Improve `markup=False`

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -621,7 +621,9 @@ class Entry(caching.Memoizable):
                              counter=counter)
 
         if footnotes:
-            return markupsafe.Markup(f"<ol>{''.join(footnotes)}</ol>")
+            if args.get('markup', True):
+                return markupsafe.Markup(f"<ol>{''.join(footnotes)}</ol>")
+            return '\n\n'.join([f'[{idx}] {content}' for idx, content in enumerate(footnotes,start=1)])
         return ''
 
     def _get_toc(self, body, more, max_depth, args) -> str:

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -623,7 +623,7 @@ class Entry(caching.Memoizable):
         if footnotes:
             if args.get('markup', True):
                 return markupsafe.Markup(f"<ol>{''.join(footnotes)}</ol>")
-            return '\n\n'.join([f'[{idx}] {content}' for idx, content in enumerate(footnotes,start=1)])
+            return '\n\n'.join([f'[{idx}] {content}' for idx, content in enumerate(footnotes, start=1)])
         return ''
 
     def _get_toc(self, body, more, max_depth, args) -> str:

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -172,12 +172,12 @@ class HTMLStripper(utils.HTMLTransform):
         return ''
 
     def handle_starttag(self, tag, attrs):
-        if tag in ('p', 'br'):
+        if tag in ('p', 'br') and tag not in self._allowed_tags:
             self.append('\n')
         self.append(self._filter(tag, attrs))
 
     def handle_endtag(self, tag):
-        if tag == 'p':
+        if tag == 'p' and tag not in self._allowed_tags:
             self.append('\n')
         if self._allowed_tags and tag in self._allowed_tags:
             self.append(f'</{tag}>')
@@ -185,7 +185,7 @@ class HTMLStripper(utils.HTMLTransform):
             self._remove_depth -= 1
 
     def handle_startendtag(self, tag, attrs):
-        if tag == 'br':
+        if tag == 'br' and tag not in self._allowed_tags:
             self.append('\n')
         self.append(self._filter(tag, attrs, start_end=True))
 

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -172,9 +172,13 @@ class HTMLStripper(utils.HTMLTransform):
         return ''
 
     def handle_starttag(self, tag, attrs):
+        if tag in ('p', 'br'):
+            self.append('\n')
         self.append(self._filter(tag, attrs))
 
     def handle_endtag(self, tag):
+        if tag == 'p':
+            self.append('\n')
         if self._allowed_tags and tag in self._allowed_tags:
             self.append(f'</{tag}>')
         elif self._remove_elements and tag in self._remove_elements:

--- a/publ/html_entry.py
+++ b/publ/html_entry.py
@@ -185,6 +185,8 @@ class HTMLStripper(utils.HTMLTransform):
             self._remove_depth -= 1
 
     def handle_startendtag(self, tag, attrs):
+        if tag == 'br':
+            self.append('\n')
         self.append(self._filter(tag, attrs, start_end=True))
 
     def handle_data(self, data):

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -402,6 +402,9 @@ class HtmlRenderer(misaka.HtmlRenderer):
         """
         LOGGER.debug("blockcode lang=%s", lang)
 
+        if not self._markup:
+            return text
+
         self._counter.blockcode(text, lang)
 
         out = '<figure class="blockcode">'
@@ -490,9 +493,9 @@ class HtmlRenderer(misaka.HtmlRenderer):
         # tag
         for element in ('div', 'figure'):
             if content.startswith(f'<{element}') and content.endswith(f'</{element}>'):
-                return '\n' + content + '\n'
+                return f'\n{content}\n'
 
-        return '<p>' + content + '</p>'
+        return f'<p>{content}</p>'
 
     def _render_image(self, spec, show, container_args, alt_text=None):
         """ Render an image specification into an <img> tag """

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -152,6 +152,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         self._counter = counter
 
+        self._markup = args.get('markup', True)
+
     def _inner(self, text):
         """ process some inner markdown """
         return misaka.Markdown(self,
@@ -184,6 +186,9 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         if self._config.get('_suppress_footnotes'):
             return '\u200b'  # zero-width space to prevent Misaka fallback
+
+        if not self._markup:
+            return f'[{self._footnote_num(num)}]'
 
         return '{sup}{link}{content}</a></sup>'.format(
             sup=utils.make_tag('sup', {
@@ -221,7 +226,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
                 'href': self._footnote_url(num, "r"),
                 'rev': 'footnote'
             }),
-            icon=self._config.get('footnotes_return', '↩'),
+            icon=self._config.get('footnotes_return', '↩' if self._markup else ''),
             partition=partition,
             after=after,
         )
@@ -323,7 +328,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
         # pylint: disable=too-many-locals
 
         # If we aren't generating images or markup, there's no reason to do any of this
-        if self._config.get('_suppress_images') or not self._config.get('markup', True):
+        if not self._markup or self._config.get('_suppress_images'):
             return ' '
 
         text = ''
@@ -464,7 +469,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
           links (default: ``False``)
         """
 
-        if not self._config.get('markup', True):
+        if not self._markup:
             return content
 
         link = links.resolve(link, self._search_path,

--- a/tests/content/plaintext/plaintext.html
+++ b/tests/content/plaintext/plaintext.html
@@ -1,0 +1,22 @@
+Date: 2026-05-24 16:58:14-07:00
+UUID: fee92df8-ead4-4621-9b25-2d55dfcab26b
+Entry-ID: 1228
+Title: Plaintext HTML entry
+
+<p>We got ourselves a fancy entry.</p>
+
+.....
+
+<p>How does this work out? Let's see.</p>
+
+<p>Also,<br>runs of short text<br>with linebreaks<br>are <em>really</em>
+	weird</p>
+
+<ul>
+	<li>Bullet list</li>
+	<li>Bullet</li>
+	<li>Bullet sublist <ul>
+			<li>item</li>
+			<li>item</li>
+		</ul></li>
+</ul>

--- a/tests/content/plaintext/plaintext.md
+++ b/tests/content/plaintext/plaintext.md
@@ -34,6 +34,6 @@ Also,
 This is
 Preformatted TEXT
     that should stay
-    the same
+      the same
 as it was before
 ```

--- a/tests/content/plaintext/plaintext.md
+++ b/tests/content/plaintext/plaintext.md
@@ -1,0 +1,39 @@
+Date: 2026-05-24 16:57:24-07:00
+UUID: fd7fe2f9-8320-421f-a215-c1df46c0a0fd
+Entry-ID: 3824
+Title: Plaintext from Markdown
+
+This is an entry.[^footnote]
+
+[^footnote]: And this is its footnote.
+
+.....
+
+This is its extended text.
+
+Here is another paragraph.
+
+We got
+many
+lines[^somany]
+that are short
+and silly
+
+[^somany]: So many lines...
+
+Also,
+
+* bullet
+* bullet
+* bullet
+    * sub-bullet
+    * sub-bullet
+* bullet
+
+```
+This is
+Preformatted TEXT
+    that should stay
+    the same
+as it was before
+```

--- a/tests/templates/plaintext/entry.txt
+++ b/tests/templates/plaintext/entry.txt
@@ -1,0 +1,12 @@
+TITLE: {{entry.title(markup=False)}}
+BODY:
+
+{{entry.body(markup=False)}}
+
+MORE:
+
+{{entry.more(markup=False)}}
+
+FOOTNOTES:
+
+{{entry.footnotes(markup=False)}}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Improve how markup=False works; fixes #623 

## Detailed description

`strip_html` will now replace `<p>` and `<br>` tags with an appropriate number of newlines if they are being stripped out, and footnotes are also properly handled.
