### PR TITLE
Give category and entry objects to exception handler pages

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -277,6 +277,9 @@ class Category(caching.Memoizable):
     def __lt__(self, other):
         return self.path < other.path
 
+    def __html__(self):
+        return self.path
+
     @cached_property
     def parent(self) -> typing.Optional["Category"]:
         """ Get the parent category """

--- a/publ/index.py
+++ b/publ/index.py
@@ -168,7 +168,7 @@ def last_indexed() -> typing.Optional[str]:
     return None
 
 
-def queue_size() -> typing.Optional[int]:
+def queue_size() -> int:
     """ Return the approximate length of the work queue """
     from .flask_wrapper import current_app
     return current_app.indexer.queue_size

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -253,13 +253,12 @@ def render_exception(error, category: typing.Optional[str] = None):
             })
 
     if isinstance(error, http_error.HTTPException):
-        error_name = error.name
-        error_code = error.code
+        h_error = error
     else:
-        error_name = "Exception Occurred"
-        error_code = 500
+        h_error = http_error.InternalServerError(description="Exception Occurred",
+            original_exception=error)
 
-    return render_error(category, error_name, error_code,
+    return render_error(category, h_error.name, h_error.code,
                         entry=flask.g.get('entry'),
                         exception={
                             'type': type(error).__name__,

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -228,7 +228,7 @@ def render_exception(error, category: typing.Optional[str] = None):
         if result:
             return result
 
-    # We can't properly map the category so let's make a best guess.
+    # If the category hasn't been provided, make a best guess based on request path
     #
     # os.path.dirname is sufficient for this guess; if this was /path/to/category
     # and category was valid, we'd have been redirected to /path/to/category/ first anyway.
@@ -253,15 +253,13 @@ def render_exception(error, category: typing.Optional[str] = None):
             })
 
     if isinstance(error, http_error.HTTPException):
-        return render_error(category, error.name, error.code,
-                            entry=flask.g.get('entry'),
-                            exception={
-                                'type': type(error).__name__,
-                                'str': error.description,
-                                'args': error.args
-                            })
+        error_name = error.name
+        error_code = error.code
+    else:
+        error_name = "Exception Occurred"
+        error_code = 500
 
-    return render_error(category, "Exception Occurred", 500,
+    return render_error(category, error_name, error_code,
                         entry=flask.g.get('entry'),
                         exception={
                             'type': type(error).__name__,

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -222,9 +222,10 @@ def render_exception(error, category:typing.Optional[str]=None):
                 destination='/' + utils.redir_path(),
                 error=flask.g.get('token_error')), 401
 
-    result = handle_path_alias()
-    if result:
-        return result
+    if isinstance(error, http_error.NotFound):
+        result = handle_path_alias()
+        if result:
+            return result
 
     # We can't properly map the category so let's make a best guess.
     #

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -156,7 +156,7 @@ def render_publ_template(template: Template, is_error=True, **kwargs) -> typing.
 
 
 @orm.db_session
-def render_error(category, error_message, error_codes,
+def render_error(category, error_message, error_codes, *,
                  entry=None,
                  exception=None,
                  headers=None) -> typing.Tuple[str, int, typing.Dict[str, str]]:
@@ -174,6 +174,7 @@ def render_error(category, error_message, error_codes,
 
     Returns a tuple of (rendered_text, status_code, headers)
     """
+    # pylint:disable=too-many-arguments
 
     LOGGER.info("Rendering error: category=%s error_message='%s' error_codes=%s exception=%s",
                 category,
@@ -202,7 +203,7 @@ def render_error(category, error_message, error_codes,
 
 
 @orm.db_session
-def render_exception(error, category:typing.Optional[str]=None):
+def render_exception(error, category: typing.Optional[str] = None):
     """ Catch-all renderer for the top-level exception handler """
 
     LOGGER.debug("render_exception %s %s", type(error), error)
@@ -212,9 +213,9 @@ def render_exception(error, category:typing.Optional[str]=None):
 
         force_ssl = config.auth.get('AUTH_FORCE_HTTPS')
         if force_ssl and request.scheme != 'https':
-            return redirect(utils.secure_link(request.endpoint,
-                                              **request.view_args,
-                                              **request.args))
+            return redirect(urllib.parse.urlunparse(
+                urllib.parse.urlparse(request.url)._replace(scheme='https')
+            ))
 
         flask.g.needs_token = True  # pylint:disable=assigning-non-slot
         if app.auth:
@@ -253,23 +254,23 @@ def render_exception(error, category:typing.Optional[str]=None):
 
     if isinstance(error, http_error.HTTPException):
         return render_error(category, error.name, error.code,
-            entry=flask.g.get('entry'),
-            exception={
-                'type': type(error).__name__,
-                'str': error.description,
-                'args': error.args
-        })
+                            entry=flask.g.get('entry'),
+                            exception={
+                                'type': type(error).__name__,
+                                'str': error.description,
+                                'args': error.args
+                            })
 
     return render_error(category, "Exception Occurred", 500,
-        entry=flask.g.get('entry'),
-        exception={
-            'type': type(error).__name__,
-            'str': str(error),
-            'args': error.args,
-    })
+                        entry=flask.g.get('entry'),
+                        exception={
+                            'type': type(error).__name__,
+                            'str': str(error),
+                            'args': error.args,
+                        })
 
 
-@orm.db_session
+@ orm.db_session
 def render_path_alias(path):
     """ Render a known path-alias (used primarily for forced .php redirects) """
 
@@ -279,7 +280,7 @@ def render_path_alias(path):
     raise http_error.NotFound("Path redirection not found")
 
 
-@orm.db_session(retry=5)
+@ orm.db_session(retry=5)
 def render_category(category='', template=None):
     """ Render a category page.
 
@@ -444,7 +445,7 @@ def _check_canon_entry_url(record):
     return None
 
 
-@orm.db_session(retry=5)
+@ orm.db_session(retry=5)
 def render_entry(entry_id, slug_text='', category=''):
     """ Render an entry page.
 
@@ -560,7 +561,7 @@ def render_entry_record(record: model.Entry, category: str, template: typing.Opt
     return rendered, headers
 
 
-@orm.db_session(retry=5)
+@ orm.db_session(retry=5)
 def admin_dashboard(by=None):  # pylint:disable=invalid-name
     """ Render the authentication dashboard """
     cur_user = user.get_active()
@@ -614,7 +615,7 @@ def render_transparent_chit():
                        'Last-Modified': 'Tue, 31 Jul 1990 08:00:00 -0000'}
 
 
-@orm.db_session
+@ orm.db_session
 def retrieve_asset(filename):
     """ Retrieves a non-image asset associated with an entry """
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -157,6 +157,7 @@ def render_publ_template(template: Template, is_error=True, **kwargs) -> typing.
 
 @orm.db_session
 def render_error(category, error_message, error_codes,
+                 entry=None,
                  exception=None,
                  headers=None) -> typing.Tuple[str, int, typing.Dict[str, str]]:
     """ Render an error page.
@@ -192,6 +193,7 @@ def render_error(category, error_message, error_codes,
         return render_publ_template(
             template,
             is_error=True,
+            entry=entry,
             category=Category.load(category),
             error={'code': error_code, 'message': error_message},
             exception=exception)[0], error_code, headers
@@ -200,7 +202,7 @@ def render_error(category, error_message, error_codes,
 
 
 @orm.db_session
-def render_exception(error):
+def render_exception(error, category:typing.Optional[str]=None):
     """ Catch-all renderer for the top-level exception handler """
 
     LOGGER.debug("render_exception %s %s", type(error), error)
@@ -224,9 +226,12 @@ def render_exception(error):
     if result:
         return result
 
-    # Effectively strip off the leading '/', so map_template can decide
-    # what the actual category is
-    category = request.path[1:]
+    # We can't properly map the category so let's make a best guess.
+    #
+    # os.path.dirname is sufficient for this guess; if this was /path/to/category
+    # and category was valid, we'd have been redirected to /path/to/category/ first anyway.
+    # The same logic applies to path_aliased categories as a whole.
+    category = flask.g.get('category', os.path.dirname(request.path)[1:])
 
     qsize = index.queue_size()
     if isinstance(error, http_error.NotFound) and (qsize or index.in_progress()):
@@ -246,16 +251,20 @@ def render_exception(error):
             })
 
     if isinstance(error, http_error.HTTPException):
-        return render_error(category, error.name, error.code, exception={
-            'type': type(error).__name__,
-            'str': error.description,
-            'args': error.args
+        return render_error(category, error.name, error.code,
+            entry=flask.g.get('entry'),
+            exception={
+                'type': type(error).__name__,
+                'str': error.description,
+                'args': error.args
         })
 
-    return render_error(category, "Exception Occurred", 500, exception={
-        'type': type(error).__name__,
-        'str': str(error),
-        'args': error.args
+    return render_error(category, "Exception Occurred", 500,
+        entry=flask.g.get('entry'),
+        exception={
+            'type': type(error).__name__,
+            'str': str(error),
+            'args': error.args,
     })
 
 
@@ -529,6 +538,9 @@ def render_entry_record(record: model.Entry, category: str, template: typing.Opt
     tmpl = map_template(category, entry_template)
     if not tmpl:
         raise http_error.BadRequest("Missing entry template" + entry_template)
+
+    flask.g.entry = entry_obj
+    flask.g.category = category
 
     rendered, etag = render_publ_template(
         tmpl,

--- a/tests/content/err/aliased.md
+++ b/tests/content/err/aliased.md
@@ -2,5 +2,6 @@ Date: 2026-05-25 00:53:36-07:00
 UUID: 3f9fc679-22e5-4f9d-8380-82dee9e0630b
 Entry-ID: 2209
 Path-Canonical: /aliased/error
+Title: Aliased entry with template error
 
 This should fail to render due to the broken `entry.html` and it should have the correct category of `err`

--- a/tests/content/err/aliased.md
+++ b/tests/content/err/aliased.md
@@ -1,0 +1,6 @@
+Date: 2026-05-25 00:53:36-07:00
+UUID: 3f9fc679-22e5-4f9d-8380-82dee9e0630b
+Entry-ID: 2209
+Path-Canonical: /aliased/error
+
+This should fail to render due to the broken `entry.html` and it should have the correct category of `err`

--- a/tests/content/err/empty-subcat/draft.md
+++ b/tests/content/err/empty-subcat/draft.md
@@ -1,0 +1,7 @@
+Title: draft in otherwise empty subcategory
+Status: DRAFT
+Date: 2026-05-25 01:40:19-07:00
+UUID: 0ca1a5c5-21c2-46c1-9a18-64d51e7c0f81
+Entry-ID: 2014
+
+This category should fail due to NotFound; this entry should fail as a 403

--- a/tests/content/err/failure.md
+++ b/tests/content/err/failure.md
@@ -1,9 +1,6 @@
-Title: failure
-Date: 2019-05-13 20:57:39-07:00
-Entry-ID: 724
-UUID: f003e67a-c3e8-5f91-8ae1-f4def03843f1
-Status: DRAFT
+Date: 2026-05-25 00:52:02-07:00
+UUID: 7b55f45b-7b67-4256-982d-dececd8a06db
+Entry-ID: 3733
+Title: failure to render
 
-This category's index should not work. In prod it should show a pretty error page, in debug it should show the exception handler.
-
-The entry itself should generate a 403.
+This should allow the category to render (but that should raise an exception), and this entry should also raise an exception

--- a/tests/content/err/subcat/draft.md
+++ b/tests/content/err/subcat/draft.md
@@ -1,4 +1,4 @@
-Title: failure
+Title: failure due to forbidden access
 Date: 2019-05-13 20:57:39-07:00
 Entry-ID: 724
 UUID: f003e67a-c3e8-5f91-8ae1-f4def03843f1

--- a/tests/content/err/subcat/draft.md
+++ b/tests/content/err/subcat/draft.md
@@ -1,0 +1,9 @@
+Title: failure
+Date: 2019-05-13 20:57:39-07:00
+Entry-ID: 724
+UUID: f003e67a-c3e8-5f91-8ae1-f4def03843f1
+Status: DRAFT
+
+This category's index should not work. In prod it should show a pretty error page, in debug it should show the exception handler.
+
+The entry itself should generate a 403.

--- a/tests/content/err/subcat/failure.md
+++ b/tests/content/err/subcat/failure.md
@@ -1,5 +1,6 @@
 Date: 2026-05-25 01:16:10-07:00
 UUID: b92466ea-b7be-413c-b6ba-21358d948a53
 Entry-ID: 3204
+Title: subcategory template failure
 
 This entry should fail to render, with a category of `err/subcat`

--- a/tests/content/err/subcat/failure.md
+++ b/tests/content/err/subcat/failure.md
@@ -1,0 +1,5 @@
+Date: 2026-05-25 01:16:10-07:00
+UUID: b92466ea-b7be-413c-b6ba-21358d948a53
+Entry-ID: 3204
+
+This entry should fail to render, with a category of `err/subcat`

--- a/tests/templates/err/entry.html
+++ b/tests/templates/err/entry.html
@@ -1,0 +1,1 @@
+{% this should fail %}

--- a/tests/templates/err/error.html
+++ b/tests/templates/err/error.html
@@ -7,7 +7,7 @@
 <body>
     <h1>{{error.message}}</h1>
 
-    <p>This is the overridden error template.</p>
+    <p>This is the overridden error template, <code>{{template.filename}}</code>.</p>
 
     <div id="errorinfo"><ul>
         <li><span>error</span> {{error.code}} {{error.message}}</li>
@@ -17,6 +17,10 @@
         <li><span>full_path</span> <code>{{request.full_path}}</code></li>
         <li><span>endpoint</span> <code>{{request.endpoint}}</code></li>
         <li><span>url_rule</span> <code>{{request.url_rule}}</code></li>
+        <li><span>category</span> <code>{{category.path}}</code></li>
+        {% if entry %}
+            <li><span>entry</span> {{entry.id}}: {{entry.title}}</li>
+        {% endif %}
     {% if exception %}
         <li><span>Exception information</span>:<ul>
             {% for key,val in exception.items() %}
@@ -27,4 +31,3 @@
     </ul></div>
 
 </body></html>
-


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Correctly maps the category and/or entry object, where possible; fixes #634 

